### PR TITLE
Ensure desktop category dropdown rebinds after navigation

### DIFF
--- a/src/components/Header/NavBar.astro
+++ b/src/components/Header/NavBar.astro
@@ -103,18 +103,34 @@ const isCategoriesActive = pathname.startsWith("/categories");
 <script is:inline>
 
   let cleanupDropdown = null;
+  let pendingDropdownRetry = null;
+
+  const scheduleDropdownRetry = () => {
+    if (pendingDropdownRetry !== null) return;
+
+    pendingDropdownRetry = requestAnimationFrame(() => {
+      pendingDropdownRetry = null;
+      initDropdown();
+    });
+  };
 
   const initDropdown = () => {
-    cleanupDropdown?.();
-
     const root = document.querySelector('[data-category-root]');
     const dropdown = root?.querySelector('[data-category-dropdown]');
     const toggleButton = root?.querySelector('[data-category-button]');
 
     if (!root || !dropdown || !toggleButton) {
-      cleanupDropdown = null;
+      scheduleDropdownRetry();
       return;
     }
+
+    if (pendingDropdownRetry !== null) {
+      cancelAnimationFrame(pendingDropdownRetry);
+      pendingDropdownRetry = null;
+    }
+
+    cleanupDropdown?.();
+    cleanupDropdown = null;
 
     const svgIcon = toggleButton.querySelector('svg');
     const categoryLinks = Array.from(dropdown.querySelectorAll('[data-category-link]'));
@@ -278,6 +294,10 @@ const isCategoriesActive = pathname.startsWith("/categories");
   document.addEventListener('astro:page-load', handlePageLoad);
   document.addEventListener('astro:after-swap', handleAfterSwap);
   document.addEventListener('astro:unload', () => {
+    if (pendingDropdownRetry !== null) {
+      cancelAnimationFrame(pendingDropdownRetry);
+      pendingDropdownRetry = null;
+    }
     cleanupDropdown?.();
     cleanupDropdown = null;
     document.removeEventListener('astro:page-load', handlePageLoad);


### PR DESCRIPTION
## Summary
- defer dropdown cleanup until replacement elements are present
- retry dropdown binding on the next animation frame when markup is temporarily missing
- cancel pending retries during unload to avoid orphaned callbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc959deb4883288af298d2f4010fca