### PR TITLE
Fix category navigation theme transitions

### DIFF
--- a/src/components/Header/SmNavBar.svelte
+++ b/src/components/Header/SmNavBar.svelte
@@ -8,6 +8,9 @@
     const categoriesButtonId = 'mobile-category-button';
     const mobileMenuId = 'mobile-navigation-menu';
 
+    const mobileNavLinkClass =
+        'block w-full pb-1 text-left transition-colors duration-200 hover:text-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text';
+
     let showMenu = false;
     let showCategories = false;
     let categoriesButton;
@@ -140,7 +143,7 @@
         >
             <ul class="flex flex-col gap-3 text-sm font-semibold uppercase tracking-[0.2em] text-secondary-text">
                 <li>
-                    <a href="/" on:click={closeMenu} class="block pb-1">
+                    <a href="/" on:click={closeMenu} class={mobileNavLinkClass}>
                         Home
                     </a>
                 </li>
@@ -148,7 +151,7 @@
                     <button
                         id={categoriesButtonId}
                         bind:this={categoriesButton}
-                        class="block w-full pb-1 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
+                        class={mobileNavLinkClass}
                         type="button"
                         on:click|stopPropagation={toggleCategories}
                         on:keydown={handleCategoriesKeydown}
@@ -185,7 +188,7 @@
                     {/if}
                 </li>
                 <li>
-                    <a href="/about" on:click={closeMenu} class="block pb-1">
+                    <a href="/about" on:click={closeMenu} class={mobileNavLinkClass}>
                         About
                     </a>
                 </li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -110,15 +110,4 @@
     overflow-x: auto;
   }
 
-  [data-category-button] {
-
-    transition-property: color, border-color, background-color, text-decoration-color, fill, stroke;
-    transition-duration: 0.2s;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-
-    transition-duration: 0.3s;
-    transition-timing-function: ease;
-
-    transition-delay: 0s;
-  }
 }


### PR DESCRIPTION
## Summary
- remove the custom transition override from the desktop category button so it matches other nav items during theme changes
- reuse a shared class for mobile navigation links to normalize spacing, alignment, and hover states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dccaa627dc8328921b0d197e7b00a6