### PR TITLE
Add publishing pitch form with client validation

### DIFF
--- a/src/components/Publishing/FormValidator.svelte
+++ b/src/components/Publishing/FormValidator.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  const invalidClasses = ["border-red-400", "focus:border-red-500", "focus:ring-red-500"];
+  const helperClass = "mt-2 text-sm text-red-500";
+  const fieldAttribute = "data-required-field";
+  const formSelector = "[data-publishing-form]";
+
+  const isFormControl = (
+    element: EventTarget | null,
+  ): element is HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement => {
+    return (
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLTextAreaElement ||
+      element instanceof HTMLSelectElement
+    );
+  };
+
+  const ensureHelper = (field: HTMLElement) => {
+    const baseId =
+      field.dataset.helperId ?? field.id ?? field.getAttribute("name") ?? `helper-${Date.now()}`;
+    const helperId = baseId.endsWith("-helper") ? baseId : `${baseId}-helper`;
+    field.dataset.helperId = helperId;
+    let helper = document.getElementById(helperId);
+
+    if (!helper) {
+      helper = document.createElement("p");
+      helper.id = helperId;
+      helper.dataset.helperFor = field.getAttribute("name") ?? helper.id;
+      helper.className = helperClass;
+      helper.hidden = true;
+      helper.setAttribute("aria-live", "polite");
+      helper.setAttribute("role", "status");
+      field.insertAdjacentElement("afterend", helper);
+    }
+
+    if (helper.id && !field.getAttribute("aria-describedby")) {
+      field.setAttribute("aria-describedby", helper.id);
+    }
+
+    return helper;
+  };
+
+  const setFieldValidity = (field: HTMLElement, invalid: boolean, message: string) => {
+    const helper = ensureHelper(field);
+    field.setAttribute("aria-invalid", invalid ? "true" : "false");
+
+    if (invalid) {
+      helper.textContent = message;
+      helper.hidden = false;
+      invalidClasses.forEach((name) => field.classList.add(name));
+    } else {
+      helper.textContent = "";
+      helper.hidden = true;
+      invalidClasses.forEach((name) => field.classList.remove(name));
+    }
+  };
+
+  const validateField = (field: HTMLElement) => {
+    if (!isFormControl(field)) {
+      return true;
+    }
+
+    const customMessage = field.dataset.validationMessage || "This field is required.";
+    const isValid = field.checkValidity();
+
+    if (!isValid) {
+      setFieldValidity(field, true, customMessage);
+    } else {
+      setFieldValidity(field, false, "");
+    }
+
+    return isValid;
+  };
+
+  const handleInput = (event: Event) => {
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+    if (!target.hasAttribute(fieldAttribute)) return;
+    validateField(target);
+  };
+
+  onMount(() => {
+    const form = document.querySelector<HTMLFormElement>(formSelector);
+    if (!form) return;
+
+    const requiredFields = Array.from(form.querySelectorAll<HTMLElement>(`[${fieldAttribute}]`));
+    requiredFields.forEach((field) => {
+      ensureHelper(field);
+      field.setAttribute("aria-invalid", "false");
+    });
+
+    const submitHandler = (event: Event) => {
+      let hasErrors = false;
+
+      requiredFields.forEach((field) => {
+        const fieldIsValid = validateField(field);
+        if (!fieldIsValid) {
+          hasErrors = true;
+        }
+      });
+
+      if (hasErrors) {
+        event.preventDefault();
+        const firstInvalid = requiredFields.find((field) => field.getAttribute("aria-invalid") === "true");
+        if (firstInvalid instanceof HTMLElement) {
+          firstInvalid.focus?.();
+        }
+      }
+    };
+
+    form.addEventListener("submit", submitHandler);
+    form.addEventListener("input", handleInput, true);
+    form.addEventListener("change", handleInput, true);
+
+    return () => {
+      form.removeEventListener("submit", submitHandler);
+      form.removeEventListener("input", handleInput, true);
+      form.removeEventListener("change", handleInput, true);
+    };
+  });
+</script>
+
+<slot />

--- a/src/pages/publishing.astro
+++ b/src/pages/publishing.astro
@@ -1,0 +1,117 @@
+---
+import PageLayout from "@/layouts/PageLayout.astro";
+import { CATEGORY_OPTIONS } from "@/utils/categories";
+import FormValidator from "@/components/Publishing/FormValidator.svelte";
+
+const introParagraphs = [
+  "Share upcoming stories or works-in-progress you'd like to see featured on Lefthand Journal.",
+  "We review every submission and follow up if the tone, research, and point of view align with our editorial mission.",
+];
+---
+
+<PageLayout title="Publishing" description="Pitch a story to the Lefthand Journal editorial desk.">
+  <section class="mx-auto max-w-3xl">
+    <div class="rounded-3xl border border-border-ink/70 bg-card-bg/95 px-8 py-10 shadow-lg shadow-black/5">
+      <div class="space-y-4 text-center sm:text-left">
+        <h1 class="font-display text-4xl text-primary-text">Pitch your next piece</h1>
+        {introParagraphs.map((paragraph) => (
+          <p class="text-base text-secondary-text">{paragraph}</p>
+        ))}
+      </div>
+
+      <form class="mt-10 space-y-6" data-publishing-form novalidate>
+        <div class="flex flex-col gap-2">
+          <label for="title" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Title</label>
+          <input
+            id="title"
+            name="title"
+            type="text"
+            placeholder="Working headline"
+            class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
+            required
+            aria-invalid="false"
+            data-required-field
+            data-helper-id="title-helper"
+            data-validation-message="Add a short, descriptive title for your piece."
+          />
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <label for="description" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Description</label>
+          <textarea
+            id="description"
+            name="description"
+            rows="4"
+            placeholder="What makes this story compelling?"
+            class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
+            required
+            aria-invalid="false"
+            data-required-field
+            data-helper-id="description-helper"
+            data-validation-message="Share a concise description so the editorial team has context."
+          ></textarea>
+        </div>
+
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
+          <div class="flex w-full flex-col gap-2">
+            <label for="pubDate" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Target publication date</label>
+            <input
+              id="pubDate"
+              name="pubDate"
+              type="date"
+              class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
+              required
+              aria-invalid="false"
+              data-required-field
+              data-helper-id="pubdate-helper"
+              data-validation-message="Let us know when you hope to publish."
+            />
+          </div>
+          <div class="flex w-full flex-col gap-2">
+            <label for="category" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Category</label>
+            <select
+              id="category"
+              name="category"
+              class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
+              required
+              aria-invalid="false"
+              data-required-field
+              data-helper-id="category-helper"
+              data-validation-message="Select the category that best fits your piece."
+            >
+              <option value="" disabled selected>Choose a category</option>
+              {CATEGORY_OPTIONS.map((option) => (
+                <option value={option}>{option}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-3">
+          <label for="notes" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Additional notes (optional)</label>
+          <textarea
+            id="notes"
+            name="notes"
+            rows="4"
+            placeholder="Links, research, or collaborators you'd like to highlight"
+            class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
+          ></textarea>
+        </div>
+
+        <div class="flex items-center justify-between gap-6 border-t border-border-ink/50 pt-6">
+          <p class="text-sm text-secondary-text">
+            Our team responds within 5 business days. All submissions remain confidential.
+          </p>
+          <button
+            type="submit"
+            class="inline-flex items-center justify-center rounded-full bg-primary-text px-6 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-primary-bg transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-text/30"
+          >
+            Submit pitch
+          </button>
+        </div>
+      </form>
+    </div>
+  </section>
+
+  <FormValidator client:load />
+</PageLayout>


### PR DESCRIPTION
## Summary
- add a new publishing page that introduces a submissions form styled to match the editorial card aesthetic
- require key fields and expose accessibility attributes so client-side validation can surface inline helper text
- implement a lightweight Svelte-based validator that prevents bad submissions and highlights invalid controls

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68dd3dc186bc8328ac3490ca61d38380