### PR TITLE
feat: gate publishing workspace access

### DIFF
--- a/src/components/Header/NavBar.astro
+++ b/src/components/Header/NavBar.astro
@@ -80,20 +80,6 @@ const focusRingClass =
 
     <li>
       <a
-        href="/publishing"
-        class:list={[
-          navLinkBaseClass,
-          pathname.startsWith("/publishing")
-            ? "text-primary-text border-b border-primary-text"
-            : "text-secondary-text hover:text-primary-text",
-        ]}
-      >
-        Publishing
-      </a>
-    </li>
-
-    <li>
-      <a
         href="/about"
         class:list={[
           navLinkBaseClass,

--- a/src/components/Header/SmNavBar.svelte
+++ b/src/components/Header/SmNavBar.svelte
@@ -188,11 +188,6 @@
                     {/if}
                 </li>
                 <li>
-                    <a href="/publishing" on:click={closeMenu} class={mobileNavLinkClass}>
-                        Publishing
-                    </a>
-                </li>
-                <li>
                     <a href="/about" on:click={closeMenu} class={mobileNavLinkClass}>
                         About
                     </a>

--- a/src/components/Publishing/PublishingGate.svelte
+++ b/src/components/Publishing/PublishingGate.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  const STORAGE_KEY = "__lfjPublishingGateUnlocked";
+  const expectedToken = (import.meta.env.PUBLIC_PUBLISHING_GATE_TOKEN ?? "").trim();
+
+  let passcode = "";
+  let unlocked = false;
+  let errorMessage = "";
+
+  const persistUnlocked = () => {
+    if (typeof window === "undefined") return;
+    try {
+      window.sessionStorage.setItem(STORAGE_KEY, "true");
+    } catch (error) {
+      console.warn("Unable to persist publishing gate state", error);
+    }
+  };
+
+  const restoreUnlocked = () => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.sessionStorage.getItem(STORAGE_KEY) === "true";
+    } catch (error) {
+      console.warn("Unable to read publishing gate state", error);
+      return false;
+    }
+  };
+
+  const unlock = () => {
+    unlocked = true;
+    errorMessage = "";
+    persistUnlocked();
+  };
+
+  const handleSubmit = () => {
+    const trimmed = passcode.trim();
+
+    if (!expectedToken) {
+      unlock();
+      return;
+    }
+
+    if (trimmed === expectedToken) {
+      unlock();
+    } else {
+      errorMessage = "Incorrect passcode. Try again or connect with the editorial team.";
+    }
+  };
+
+  onMount(() => {
+    if (typeof window === "undefined") return;
+    if (restoreUnlocked()) {
+      unlocked = true;
+    }
+  });
+</script>
+
+{#if unlocked}
+  <slot />
+{:else}
+  <section class="flex min-h-[60vh] items-center justify-center py-24">
+    <div class="w-full max-w-md rounded-3xl border border-border-ink/70 bg-card-bg/95 px-8 py-10 text-center shadow-lg shadow-black/5">
+      <p class="text-xs font-semibold uppercase tracking-[0.35em] text-muted-text">Publishing studio</p>
+      <h1 class="mt-4 font-display text-3xl text-primary-text">Unlock the workspace</h1>
+      <p class="mt-3 text-sm text-secondary-text">
+        This private space keeps pitches and production details within the editorial circle. Enter the shared passcode to continue.
+      </p>
+
+      <form
+        class="mt-8 space-y-4 text-left"
+        on:submit|preventDefault={handleSubmit}
+      >
+        <label class="flex flex-col gap-2">
+          <span class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">Passcode</span>
+          <input
+            type="password"
+            class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
+            bind:value={passcode}
+            autocomplete="current-password"
+            aria-invalid={errorMessage ? "true" : "false"}
+            aria-describedby={errorMessage ? "publishing-gate-error" : undefined}
+            required
+          />
+        </label>
+
+        {#if errorMessage}
+          <p id="publishing-gate-error" class="text-sm text-red-500" role="status" aria-live="polite">
+            {errorMessage}
+          </p>
+        {/if}
+
+        <button
+          type="submit"
+          class="inline-flex w-full items-center justify-center rounded-full bg-primary-text px-6 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-primary-bg transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-text/30"
+        >
+          Unlock
+        </button>
+      </form>
+
+      <p class="mt-6 text-xs text-muted-text">
+        Need the passcode? Ping the managing editor for access.
+      </p>
+    </div>
+  </section>
+{/if}

--- a/src/pages/publishing.astro
+++ b/src/pages/publishing.astro
@@ -2,6 +2,7 @@
 import PageLayout from "@/layouts/PageLayout.astro";
 import { CATEGORY_OPTIONS } from "@/utils/categories";
 import FormValidator from "@/components/Publishing/FormValidator.svelte";
+import PublishingGate from "@/components/Publishing/PublishingGate.svelte";
 import { getCollection, type CollectionEntry } from "astro:content";
 
 // Intro copy for the Pitch section
@@ -122,115 +123,116 @@ const checkboxClass =
   title="Publishing"
   description="Pitch a story and manage releases with the same calm precision."
 >
-  <!-- Pitch: submission form -->
-  <section class="mx-auto max-w-3xl">
-    <div class="rounded-3xl border border-border-ink/70 bg-card-bg/95 px-8 py-10 shadow-lg shadow-black/5">
-      <div class="space-y-4 text-center sm:text-left">
-        <h1 class="font-display text-4xl text-primary-text">Pitch your next piece</h1>
-        {introParagraphs.map((paragraph) => (
-          <p class="text-base text-secondary-text">{paragraph}</p>
-        ))}
-      </div>
-
-      <form class="mt-10 space-y-6" data-publishing-form novalidate>
-        <div class="flex flex-col gap-2">
-          <label for="title" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Title</label>
-          <input
-            id="title"
-            name="title"
-            type="text"
-            placeholder="Working headline"
-            class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
-            required
-            aria-invalid="false"
-            data-required-field
-            data-helper-id="title-helper"
-            data-validation-message="Add a short, descriptive title for your piece."
-          />
+  <PublishingGate client:load>
+    <!-- Pitch: submission form -->
+    <section class="mx-auto max-w-3xl">
+      <div class="rounded-3xl border border-border-ink/70 bg-card-bg/95 px-8 py-10 shadow-lg shadow-black/5">
+        <div class="space-y-4 text-center sm:text-left">
+          <h1 class="font-display text-4xl text-primary-text">Pitch your next piece</h1>
+          {introParagraphs.map((paragraph) => (
+            <p class="text-base text-secondary-text">{paragraph}</p>
+          ))}
         </div>
 
-        <div class="flex flex-col gap-2">
-          <label for="description" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Description</label>
-          <textarea
-            id="description"
-            name="description"
-            rows="4"
-            placeholder="What makes this story compelling?"
-            class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
-            required
-            aria-invalid="false"
-            data-required-field
-            data-helper-id="description-helper"
-            data-validation-message="Share a concise description so the editorial team has context."
-          ></textarea>
-        </div>
-
-        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
-          <div class="flex w-full flex-col gap-2">
-            <label for="pubDate" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Target publication date</label>
+        <form class="mt-10 space-y-6" data-publishing-form novalidate>
+          <div class="flex flex-col gap-2">
+            <label for="title" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Title</label>
             <input
-              id="pubDate"
-              name="pubDate"
-              type="date"
+              id="title"
+              name="title"
+              type="text"
+              placeholder="Working headline"
               class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
               required
               aria-invalid="false"
               data-required-field
-              data-helper-id="pubdate-helper"
-              data-validation-message="Let us know when you hope to publish."
+              data-helper-id="title-helper"
+              data-validation-message="Add a short, descriptive title for your piece."
             />
           </div>
-          <div class="flex w-full flex-col gap-2">
-            <label for="category" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Category</label>
-            <select
-              id="category"
-              name="category"
+
+          <div class="flex flex-col gap-2">
+            <label for="description" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Description</label>
+            <textarea
+              id="description"
+              name="description"
+              rows="4"
+              placeholder="What makes this story compelling?"
               class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
               required
               aria-invalid="false"
               data-required-field
-              data-helper-id="category-helper"
-              data-validation-message="Select the category that best fits your piece."
-            >
-              <option value="" disabled selected>Choose a category</option>
-              {CATEGORY_OPTIONS.map((option) => (
-                <option value={option}>{option}</option>
-              ))}
-            </select>
+              data-helper-id="description-helper"
+              data-validation-message="Share a concise description so the editorial team has context."
+            ></textarea>
           </div>
-        </div>
 
-        <div class="flex flex-col gap-3">
-          <label for="notes" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Additional notes (optional)</label>
-          <textarea
-            id="notes"
-            name="notes"
-            rows="4"
-            placeholder="Links, research, or collaborators you'd like to highlight"
-            class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
-          ></textarea>
-        </div>
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
+            <div class="flex w-full flex-col gap-2">
+              <label for="pubDate" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Target publication date</label>
+              <input
+                id="pubDate"
+                name="pubDate"
+                type="date"
+                class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
+                required
+                aria-invalid="false"
+                data-required-field
+                data-helper-id="pubdate-helper"
+                data-validation-message="Let us know when you hope to publish."
+              />
+            </div>
+            <div class="flex w-full flex-col gap-2">
+              <label for="category" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Category</label>
+              <select
+                id="category"
+                name="category"
+                class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
+                required
+                aria-invalid="false"
+                data-required-field
+                data-helper-id="category-helper"
+                data-validation-message="Select the category that best fits your piece."
+              >
+                <option value="" disabled selected>Choose a category</option>
+                {CATEGORY_OPTIONS.map((option) => (
+                  <option value={option}>{option}</option>
+                ))}
+              </select>
+            </div>
+          </div>
 
-        <div class="flex items-center justify-between gap-6 border-t border-border-ink/50 pt-6">
-          <p class="text-sm text-secondary-text">
-            Our team responds within 5 business days. All submissions remain confidential.
-          </p>
-          <button
-            type="submit"
-            class="inline-flex items-center justify-center rounded-full bg-primary-text px-6 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-primary-bg transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-text/30"
-          >
-            Submit pitch
-          </button>
-        </div>
-      </form>
-    </div>
+          <div class="flex flex-col gap-3">
+            <label for="notes" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Additional notes (optional)</label>
+            <textarea
+              id="notes"
+              name="notes"
+              rows="4"
+              placeholder="Links, research, or collaborators you'd like to highlight"
+              class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
+            ></textarea>
+          </div>
 
-    <!-- client-side validation for the pitch form -->
-    <FormValidator client:load />
-  </section>
+          <div class="flex items-center justify-between gap-6 border-t border-border-ink/50 pt-6">
+            <p class="text-sm text-secondary-text">
+              Our team responds within 5 business days. All submissions remain confidential.
+            </p>
+            <button
+              type="submit"
+              class="inline-flex items-center justify-center rounded-full bg-primary-text px-6 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-primary-bg transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-text/30"
+            >
+              Submit pitch
+            </button>
+          </div>
+        </form>
+      </div>
 
-  <!-- Publishing Studio: metrics, coverage, queue -->
-  <section class="mt-16 flex flex-col gap-12">
+      <!-- client-side validation for the pitch form -->
+      <FormValidator client:load />
+    </section>
+
+    <!-- Publishing Studio: metrics, coverage, queue -->
+    <section class="mt-16 flex flex-col gap-12">
     <div class="flex flex-col gap-4">
       <p class="text-sm uppercase tracking-[0.3em] text-muted-text">
         Editorial control center
@@ -455,4 +457,5 @@ const checkboxClass =
       </div>
     </section>
   </section>
+  </PublishingGate>
 </PageLayout>


### PR DESCRIPTION
## Summary
- remove the Publishing link from both desktop and mobile header navigation
- add a client-hydrated PublishingGate component that checks a shared passcode and stores unlock state in session storage
- wrap the Publishing page content with the new gate so the workspace remains hidden until unlocked

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd591966dc8328b8d1ea7be86ea6eb