### PR TITLE
Add publishing backend schema, docs, and API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ npm run preview
 ```
 
 The project ships as a static site and can be deployed to any static hosting provider.
+
+## Publishing & database operations
+
+For Hostinger setup instructions, SQL schema details, API endpoint overview, and export/import guidance, see [docs/publishing.md](docs/publishing.md).

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,95 @@
+# Publishing & Hostinger Operations
+
+This guide explains how to run the SQL schema, connect the Astro app to Hostinger's MySQL service, and keep editorial content backed up.
+
+## 1. Provision the database
+
+1. In Hostinger, open **Websites → Manage → Databases** and create a new MySQL database.
+2. Note the database name, username, password, and the server/host name that Hostinger provides (for example, `mysql123.hostinger.com`).
+3. Open **phpMyAdmin** from the same panel. The interface loads the Hostinger-managed database.
+
+## 2. Apply the schema
+
+1. Inside phpMyAdmin, select your database from the left sidebar.
+2. Click the **Import** tab.
+3. Choose the `sql/schema.sql` file from this repository and press **Go**. phpMyAdmin will execute the SQL and create the `users`, `categories`, `posts`, and `post_assets` tables along with their indexes.
+4. Optionally save the executed query output as confirmation in your deployment notes.
+
+## 3. Configure application credentials
+
+Create an `.env` (and optionally `.env.production`) file in the project root with your Hostinger credentials:
+
+```bash
+DB_HOST="mysql123.hostinger.com"
+DB_PORT="3306"
+DB_NAME="lefthand_journal"
+DB_USER="lefthand_editor"
+DB_PASSWORD="super-secret-password"
+```
+
+These environment variables are read by `src/utils/db.ts` when the serverless endpoints run. Never commit the `.env` file to version control—Hostinger will let you configure the same values in its **Environment Variables** panel for production builds.
+
+## 4. Drafts vs. published content
+
+The schema stores each post's lifecycle in the `status` field:
+
+- `draft` – editable content not shown publicly.
+- `scheduled` – ready to go live at `scheduled_publish_at`. A scheduled post is treated as published automatically when that timestamp is in the past.
+- `published` – publicly visible immediately.
+- `archived` – preserved for reference but hidden from regular listings.
+
+API endpoints filter published content with the following logic:
+
+```sql
+WHERE status = 'published'
+  AND (scheduled_publish_at IS NULL OR scheduled_publish_at <= NOW())
+```
+
+Draft views omit that clause so editors can see everything.
+
+## 5. CRUD & editorial tooling endpoints
+
+Serverless endpoints under `src/pages/api/publishing/` provide the following capabilities:
+
+| Endpoint | Method | Purpose |
+| --- | --- | --- |
+| `/api/publishing/posts` | `GET` | List posts with optional `status`, `category`, `limit`, and `offset` filters. |
+| `/api/publishing/posts` | `POST` | Create a new post from JSON payload fields. |
+| `/api/publishing/posts/[id]` | `GET` | Retrieve a single post plus author/category context. |
+| `/api/publishing/posts/[id]` | `PUT` | Update an existing post's fields. |
+| `/api/publishing/posts/[id]` | `DELETE` | Remove a post and its assets. |
+| `/api/publishing/posts/[id]/preview` | `GET` | Return the latest saved draft for preview rendering. |
+| `/api/publishing/posts/[id]/duplicate` | `POST` | Clone a post into a new draft with a unique slug. |
+| `/api/publishing/posts/[id]/publish` | `POST` | Toggle publish/unpublish states and optionally set `scheduled_publish_at`. |
+
+All endpoints return JSON. They rely on the shared connection pool defined in `src/utils/db.ts`.
+
+## 6. Export and import backups
+
+Keeping the editorial archive safe is easy with phpMyAdmin:
+
+### SQL dump (full backup)
+
+1. In phpMyAdmin, select the database.
+2. Click **Export** → choose **Custom**.
+3. Tick `users`, `categories`, `posts`, and `post_assets`.
+4. Under **Output**, pick `Compression: gzipped` for smaller downloads if desired.
+5. Click **Go** to download an SQL dump. Store this securely (for example, in an encrypted cloud drive).
+
+To restore, use the **Import** tab on an empty database and upload the `.sql` (or `.sql.gz`) file. phpMyAdmin will recreate tables and data.
+
+### CSV exports (granular backups)
+
+1. From the left sidebar, select a table such as `posts`.
+2. Click the **Export** tab and choose the `CSV` format.
+3. Enable column headers and UTF-8 encoding for spreadsheet compatibility.
+4. Repeat for `categories` and `users` if you need separate CSV files.
+
+To import CSV data:
+
+1. Open the target table in phpMyAdmin.
+2. Click **Import** and upload the CSV.
+3. Configure the delimiter (usually comma) and column mappings if your CSV headers differ.
+4. Execute the import. phpMyAdmin will append rows to the table.
+
+Always export a fresh SQL dump before running destructive operations such as truncating tables or bulk updates.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@astrojs/vercel": "^7.7.0",
     "astro": "^4.2.8",
     "astro-icon": "^1.0.4",
+    "mysql2": "^3.9.4",
     "svelte": "^4.2.9",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,62 @@
+-- Lefthand Journal database schema
+-- Run this file in your MySQL-compatible Hostinger database (MariaDB 10.6+).
+
+CREATE TABLE IF NOT EXISTS users (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(150) NOT NULL,
+  email VARCHAR(191) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NULL,
+  avatar_url VARCHAR(255) NULL,
+  bio TEXT NULL,
+  role ENUM('author', 'editor', 'admin') NOT NULL DEFAULT 'author',
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS categories (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  slug VARCHAR(191) NOT NULL UNIQUE,
+  name VARCHAR(150) NOT NULL,
+  description TEXT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS posts (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  slug VARCHAR(191) NOT NULL,
+  status ENUM('draft', 'scheduled', 'published', 'archived') NOT NULL DEFAULT 'draft',
+  title VARCHAR(200) NOT NULL,
+  excerpt TEXT NULL,
+  body_html MEDIUMTEXT NOT NULL,
+  cover_image_url VARCHAR(255) NULL,
+  cover_image_alt VARCHAR(255) NULL,
+  category_id BIGINT UNSIGNED NOT NULL,
+  author_id BIGINT UNSIGNED NOT NULL,
+  scheduled_publish_at DATETIME NULL,
+  published_at DATETIME NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_posts_category FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT fk_posts_author FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT uq_posts_slug UNIQUE (slug)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS post_assets (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  post_id BIGINT UNSIGNED NOT NULL,
+  asset_type ENUM('image', 'video', 'file', 'embed') NOT NULL DEFAULT 'image',
+  url VARCHAR(255) NOT NULL,
+  alt_text VARCHAR(255) NULL,
+  caption TEXT NULL,
+  sort_order INT UNSIGNED NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_assets_post FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_posts_slug ON posts (slug);
+CREATE INDEX idx_posts_status ON posts (status);
+CREATE INDEX idx_posts_category ON posts (category_id);
+
+CREATE INDEX idx_assets_post_sort ON post_assets (post_id, sort_order);

--- a/src/pages/api/publishing/posts.ts
+++ b/src/pages/api/publishing/posts.ts
@@ -1,0 +1,106 @@
+import type { APIRoute } from 'astro';
+import { execute, jsonResponse, query } from '../../../utils/db';
+
+type PostPayload = {
+  slug: string;
+  status?: 'draft' | 'scheduled' | 'published' | 'archived';
+  title: string;
+  excerpt?: string | null;
+  bodyHtml: string;
+  coverImageUrl?: string | null;
+  coverImageAlt?: string | null;
+  categoryId: number;
+  authorId: number;
+  scheduledPublishAt?: string | null;
+};
+
+const parseNumber = (value: string | null, fallback: number): number => {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+};
+
+export const GET: APIRoute = async ({ request }) => {
+  try {
+    const url = new URL(request.url);
+    const status = url.searchParams.get('status');
+    const category = url.searchParams.get('category');
+    const limit = parseNumber(url.searchParams.get('limit'), 20);
+    const offset = parseNumber(url.searchParams.get('offset'), 0);
+
+    const filters: string[] = [];
+    const params: unknown[] = [];
+
+    if (status) {
+      if (status === 'published') {
+        filters.push(
+          "(p.status = 'published' AND (p.scheduled_publish_at IS NULL OR p.scheduled_publish_at <= NOW()))",
+        );
+      } else {
+        filters.push('p.status = ?');
+        params.push(status);
+      }
+    }
+
+    if (category) {
+      const categoryId = Number(category);
+      if (Number.isFinite(categoryId)) {
+        filters.push('p.category_id = ?');
+        params.push(categoryId);
+      } else {
+        filters.push('c.slug = ?');
+        params.push(category);
+      }
+    }
+
+    const whereClause = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
+
+    const rows = await query(
+      `SELECT p.*, c.name AS category_name, c.slug AS category_slug, u.name AS author_name
+       FROM posts p
+       JOIN categories c ON c.id = p.category_id
+       JOIN users u ON u.id = p.author_id
+       ${whereClause}
+       ORDER BY p.updated_at DESC
+       LIMIT ? OFFSET ?`,
+      [...params, limit, offset],
+    );
+
+    return jsonResponse({ data: rows });
+  } catch (error) {
+    console.error(error);
+    return jsonResponse({ error: 'Failed to fetch posts.' }, { status: 500 });
+  }
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const payload = (await request.json()) as PostPayload;
+
+    if (!payload.slug || !payload.title || !payload.bodyHtml) {
+      return jsonResponse({ error: 'slug, title, and bodyHtml are required.' }, { status: 400 });
+    }
+
+    const result = await execute(
+      `INSERT INTO posts (slug, status, title, excerpt, body_html, cover_image_url, cover_image_alt, category_id, author_id, scheduled_publish_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        payload.slug,
+        payload.status ?? 'draft',
+        payload.title,
+        payload.excerpt ?? null,
+        payload.bodyHtml,
+        payload.coverImageUrl ?? null,
+        payload.coverImageAlt ?? null,
+        payload.categoryId,
+        payload.authorId,
+        payload.scheduledPublishAt ?? null,
+      ],
+    );
+
+    return jsonResponse({ id: result.insertId }, { status: 201 });
+  } catch (error) {
+    console.error(error);
+    return jsonResponse({ error: 'Failed to create post.' }, { status: 500 });
+  }
+};

--- a/src/pages/api/publishing/posts/[id].ts
+++ b/src/pages/api/publishing/posts/[id].ts
@@ -1,0 +1,100 @@
+import type { APIRoute } from 'astro';
+import { execute, jsonResponse, queryOne } from '../../../../utils/db';
+
+const notFound = () => jsonResponse({ error: 'Post not found.' }, { status: 404 });
+
+const parseId = (params: Record<string, string | undefined>) => {
+  const id = Number(params.id);
+  if (!Number.isFinite(id) || id <= 0) {
+    throw new Error('Invalid post id');
+  }
+  return id;
+};
+
+export const GET: APIRoute = async ({ params }) => {
+  try {
+    const id = parseId(params);
+    const post = await queryOne(
+      `SELECT p.*, c.name AS category_name, c.slug AS category_slug, u.name AS author_name, u.email AS author_email
+       FROM posts p
+       JOIN categories c ON c.id = p.category_id
+       JOIN users u ON u.id = p.author_id
+       WHERE p.id = ?`,
+      [id],
+    );
+
+    if (!post) {
+      return notFound();
+    }
+
+    return jsonResponse({ data: post });
+  } catch (error) {
+    console.error(error);
+    return jsonResponse({ error: 'Failed to fetch post.' }, { status: 400 });
+  }
+};
+
+export const PUT: APIRoute = async ({ params, request }) => {
+  try {
+    const id = parseId(params);
+    const updates = (await request.json()) as Record<string, unknown>;
+
+    const fields: string[] = [];
+    const values: unknown[] = [];
+
+    const allowed: Record<string, string> = {
+      slug: 'slug = ?',
+      status: 'status = ?',
+      title: 'title = ?',
+      excerpt: 'excerpt = ?',
+      bodyHtml: 'body_html = ?',
+      coverImageUrl: 'cover_image_url = ?',
+      coverImageAlt: 'cover_image_alt = ?',
+      categoryId: 'category_id = ?',
+      authorId: 'author_id = ?',
+      scheduledPublishAt: 'scheduled_publish_at = ?',
+      publishedAt: 'published_at = ?',
+    };
+
+    for (const key of Object.keys(allowed)) {
+      if (key in updates) {
+        fields.push(allowed[key]);
+        values.push(updates[key]);
+      }
+    }
+
+    if (fields.length === 0) {
+      return jsonResponse({ error: 'No valid fields supplied.' }, { status: 400 });
+    }
+
+    values.push(id);
+
+    await execute(
+      `UPDATE posts SET ${fields.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+      values,
+    );
+
+    return jsonResponse({ success: true });
+  } catch (error) {
+    console.error(error);
+    return jsonResponse({ error: 'Failed to update post.' }, { status: 400 });
+  }
+};
+
+export const DELETE: APIRoute = async ({ params }) => {
+  try {
+    const id = parseId(params);
+
+    await execute('DELETE FROM post_assets WHERE post_id = ?', [id]);
+    const result = await execute('DELETE FROM posts WHERE id = ?', [id]);
+
+    if (result.affectedRows === 0) {
+      return notFound();
+    }
+
+    return jsonResponse({ success: true });
+  } catch (error) {
+    console.error(error);
+    return jsonResponse({ error: 'Failed to delete post.' }, { status: 400 });
+  }
+};

--- a/src/pages/api/publishing/posts/[id]/duplicate.ts
+++ b/src/pages/api/publishing/posts/[id]/duplicate.ts
@@ -1,0 +1,39 @@
+import type { APIRoute } from 'astro';
+import { execute, jsonResponse, queryOne } from '../../../../../utils/db';
+
+export const POST: APIRoute = async ({ params }) => {
+  try {
+    const id = Number(params.id);
+    if (!Number.isFinite(id) || id <= 0) {
+      return jsonResponse({ error: 'Invalid post id.' }, { status: 400 });
+    }
+
+    const original = await queryOne<any>('SELECT * FROM posts WHERE id = ?', [id]);
+    if (!original) {
+      return jsonResponse({ error: 'Post not found.' }, { status: 404 });
+    }
+
+    const timestamp = Date.now();
+    const newSlug = `${original.slug}-copy-${timestamp}`;
+
+    const result = await execute(
+      `INSERT INTO posts (slug, status, title, excerpt, body_html, cover_image_url, cover_image_alt, category_id, author_id, scheduled_publish_at)
+       VALUES (?, 'draft', ?, ?, ?, ?, ?, ?, ?, NULL)`,
+      [
+        newSlug,
+        `${original.title} (Copy)`,
+        original.excerpt,
+        original.body_html,
+        original.cover_image_url,
+        original.cover_image_alt,
+        original.category_id,
+        original.author_id,
+      ],
+    );
+
+    return jsonResponse({ id: result.insertId, slug: newSlug }, { status: 201 });
+  } catch (error) {
+    console.error(error);
+    return jsonResponse({ error: 'Failed to duplicate post.' }, { status: 500 });
+  }
+};

--- a/src/pages/api/publishing/posts/[id]/preview.ts
+++ b/src/pages/api/publishing/posts/[id]/preview.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from 'astro';
+import { jsonResponse, queryOne } from '../../../../../utils/db';
+
+export const GET: APIRoute = async ({ params }) => {
+  try {
+    const id = Number(params.id);
+    if (!Number.isFinite(id) || id <= 0) {
+      return jsonResponse({ error: 'Invalid post id.' }, { status: 400 });
+    }
+
+    const post = await queryOne(
+      `SELECT p.*, u.name AS author_name, u.email AS author_email, c.slug AS category_slug
+       FROM posts p
+       JOIN users u ON u.id = p.author_id
+       JOIN categories c ON c.id = p.category_id
+       WHERE p.id = ?`,
+      [id],
+    );
+
+    if (!post) {
+      return jsonResponse({ error: 'Post not found.' }, { status: 404 });
+    }
+
+    return jsonResponse({ data: post });
+  } catch (error) {
+    console.error(error);
+    return jsonResponse({ error: 'Failed to load preview.' }, { status: 500 });
+  }
+};

--- a/src/pages/api/publishing/posts/[id]/publish.ts
+++ b/src/pages/api/publishing/posts/[id]/publish.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from 'astro';
+import { execute, jsonResponse } from '../../../../../utils/db';
+
+type PublishPayload = {
+  publish: boolean;
+  scheduledPublishAt?: string | null;
+};
+
+export const POST: APIRoute = async ({ params, request }) => {
+  try {
+    const id = Number(params.id);
+    if (!Number.isFinite(id) || id <= 0) {
+      return jsonResponse({ error: 'Invalid post id.' }, { status: 400 });
+    }
+
+    const body = (await request.json()) as PublishPayload;
+    const nextStatus = body.publish ? 'published' : 'draft';
+    const scheduled = body.publish ? body.scheduledPublishAt ?? null : null;
+
+    await execute(
+      `UPDATE posts SET status = ?, scheduled_publish_at = ?, updated_at = CURRENT_TIMESTAMP${
+        body.publish ? ', published_at = COALESCE(published_at, NOW())' : ''
+      } WHERE id = ?`,
+      [nextStatus, scheduled, id],
+    );
+
+    return jsonResponse({ success: true, status: nextStatus, scheduledPublishAt: scheduled });
+  } catch (error) {
+    console.error(error);
+    return jsonResponse({ error: 'Failed to update publish state.' }, { status: 500 });
+  }
+};

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,0 +1,70 @@
+import mysql from 'mysql2/promise';
+
+type ConnectionOptions = {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+};
+
+let pool: mysql.Pool | null = null;
+
+function getConfig(): ConnectionOptions {
+  const {
+    DB_HOST,
+    DB_PORT,
+    DB_USER,
+    DB_PASSWORD,
+    DB_NAME,
+  } = process.env;
+
+  if (!DB_HOST || !DB_USER || !DB_PASSWORD || !DB_NAME) {
+    throw new Error('Database environment variables are missing. Set DB_HOST, DB_USER, DB_PASSWORD, and DB_NAME.');
+  }
+
+  return {
+    host: DB_HOST,
+    port: DB_PORT ? Number(DB_PORT) : 3306,
+    user: DB_USER,
+    password: DB_PASSWORD,
+    database: DB_NAME,
+  };
+}
+
+export function getPool(): mysql.Pool {
+  if (!pool) {
+    pool = mysql.createPool({
+      ...getConfig(),
+      waitForConnections: true,
+      connectionLimit: 10,
+      charset: 'utf8mb4_unicode_ci',
+    });
+  }
+
+  return pool;
+}
+
+export async function query<T = mysql.RowDataPacket[]>(sql: string, params: unknown[] = []): Promise<T[]> {
+  const [rows] = await getPool().query<T[]>(sql, params);
+  return rows;
+}
+
+export async function queryOne<T = mysql.RowDataPacket>(sql: string, params: unknown[] = []): Promise<T | null> {
+  const rows = await query<T>(sql, params);
+  return rows.length > 0 ? rows[0] : null;
+}
+
+export async function execute(sql: string, params: unknown[] = []): Promise<mysql.ResultSetHeader> {
+  const [result] = await getPool().execute<mysql.ResultSetHeader>(sql, params);
+  return result;
+}
+
+export function jsonResponse(data: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set('Content-Type', 'application/json');
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers,
+  });
+}


### PR DESCRIPTION
## Summary
- add a MySQL schema with publishing tables, relationships, and indexes
- document Hostinger database setup, environment configuration, and content export/import guidance
- add a shared MySQL data layer and API routes for editorial CRUD, preview, duplication, and publish workflows

## Testing
- `npm run build` *(fails: mysql2 package download blocked by npm registry 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd591b55ac8328abe88d2e5cfd27ba