### PR TITLE
Rebuild publishing studio workspace

### DIFF
--- a/src/components/Publishing/DonutChart.svelte
+++ b/src/components/Publishing/DonutChart.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  export type DonutSegment = {
+    label: string;
+    value: number;
+    color: string;
+  };
+
+  export let segments: DonutSegment[] = [];
+  export let total = 0;
+  export let trackColor = "rgba(var(--border-ink), 0.5)";
+
+  const radius = 56;
+  const strokeWidth = 14;
+  const circumference = 2 * Math.PI * radius;
+
+  $: computedSegments = (() => {
+    let offset = 0;
+    return segments.map((segment) => {
+      const length = total > 0 ? (segment.value / total) * circumference : 0;
+      const current = { ...segment, length, offset };
+      offset -= length;
+      return current;
+    });
+  })();
+</script>
+
+<svg
+  viewBox="0 0 140 140"
+  role="img"
+  aria-label="Category distribution"
+  class="h-32 w-32"
+>
+  <circle
+    cx="70"
+    cy="70"
+    r={radius}
+    fill="transparent"
+    stroke={trackColor}
+    stroke-width={strokeWidth}
+    stroke-dasharray={`${circumference} ${circumference}`}
+    stroke-dashoffset={0}
+    class="opacity-30"
+  />
+
+  {#each computedSegments as segment (segment.label)}
+    <circle
+      cx="70"
+      cy="70"
+      r={radius}
+      fill="transparent"
+      stroke={segment.color}
+      stroke-width={strokeWidth}
+      stroke-linecap="round"
+      stroke-dasharray={`${segment.length} ${circumference}`}
+      stroke-dashoffset={segment.offset}
+      class="transition-[stroke-dashoffset] duration-500 ease-out"
+    />
+  {/each}
+</svg>

--- a/src/components/Publishing/PreviewModal.svelte
+++ b/src/components/Publishing/PreviewModal.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import type { PublishingPost } from "./types";
+
+  export let open = false;
+  export let post: PublishingPost | null = null;
+
+  const dispatch = createEventDispatcher();
+
+  const escapeHtml = (text: string) =>
+    text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+
+  const escapeAttribute = (value: string) =>
+    value
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/</g, "&lt;");
+
+  const inlineMath = (expression: string) => {
+    const escaped = escapeHtml(expression.trim());
+    return `<span class=\"inline-flex items-center gap-1 rounded-full bg-surface-bg/80 px-2 py-1 font-mono text-sm text-primary-text\">${escaped}</span>`;
+  };
+
+  const applyInlineFormatting = (input: string) => {
+    let formatted = escapeHtml(input);
+
+    formatted = formatted.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, alt, url) => {
+      const safeUrl = escapeAttribute(url.trim());
+      const safeAlt = escapeAttribute(alt.trim() || "Inline illustration");
+      return `<img src=\"${safeUrl}\" alt=\"${safeAlt}\" class=\"my-6 w-full rounded-2xl border border-border-ink/50 bg-surface-bg\" loading=\"lazy\" />`;
+    });
+
+    formatted = formatted.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, url) => {
+      const safeUrl = escapeAttribute(url.trim());
+      const safeLabel = escapeHtml(label.trim());
+      return `<a href=\"${safeUrl}\" class=\"underline decoration-border-ink/70 decoration-1 underline-offset-2 transition hover:decoration-primary-text\" target=\"_blank\" rel=\"noopener noreferrer\">${safeLabel}</a>`;
+    });
+
+    formatted = formatted.replace(/`([^`]+)`/g, (_match, code) => `<code class=\"rounded bg-surface-bg px-1 py-0.5 text-sm\">${code}</code>`);
+    formatted = formatted.replace(/\*\*([^*]+)\*\*/g, (_match, text) => `<strong>${text}</strong>`);
+    formatted = formatted.replace(/_([^_]+)_/g, (_match, text) => `<em>${text}</em>`);
+    formatted = formatted.replace(/\\\((.+?)\\\)/g, (_match, expression) => inlineMath(expression));
+
+    return formatted;
+  };
+
+  const renderMarkdown = (markdown: string) => {
+    const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+    let html = "";
+    let listItems: string[] = [];
+    let quoteLines: string[] = [];
+    let inCodeBlock = false;
+    let codeLines: string[] = [];
+
+    const flushList = () => {
+      if (listItems.length === 0) return;
+      html += `<ul class=\"list-disc space-y-2 pl-6 marker:text-secondary-text\">${listItems
+        .map((item) => `<li>${applyInlineFormatting(item)}</li>`)
+        .join("")}</ul>`;
+      listItems = [];
+    };
+
+    const flushQuote = () => {
+      if (quoteLines.length === 0) return;
+      html += `<blockquote class=\"border-l-4 border-border-ink/70 pl-5 text-secondary-text space-y-2\">${quoteLines
+        .map((line) => `<p>${applyInlineFormatting(line)}</p>`)
+        .join("")}</blockquote>`;
+      quoteLines = [];
+    };
+
+    const flushCode = () => {
+      if (!inCodeBlock) return;
+      html += `<pre><code>${escapeHtml(codeLines.join("\n"))}</code></pre>`;
+      inCodeBlock = false;
+      codeLines = [];
+    };
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+
+      if (trimmed.startsWith("```")) {
+        if (!inCodeBlock) {
+          flushList();
+          flushQuote();
+          inCodeBlock = true;
+          codeLines = [];
+        } else {
+          flushCode();
+        }
+        continue;
+      }
+
+      if (inCodeBlock) {
+        codeLines.push(line);
+        continue;
+      }
+
+      if (trimmed.length === 0) {
+        flushList();
+        flushQuote();
+        continue;
+      }
+
+      if (trimmed.startsWith("- ")) {
+        flushQuote();
+        listItems.push(trimmed.slice(2));
+        continue;
+      }
+
+      if (trimmed.startsWith(">")) {
+        flushList();
+        quoteLines.push(trimmed.replace(/^>\s?/, ""));
+        continue;
+      }
+
+      flushList();
+      flushQuote();
+
+      const headingMatch = trimmed.match(/^(#{1,3})\s+(.*)$/);
+      if (headingMatch) {
+        const level = Math.min(headingMatch[1].length + 1, 4);
+        html += `<h${level} class=\"font-display text-primary-text\">${applyInlineFormatting(
+          headingMatch[2]
+        )}</h${level}>`;
+        continue;
+      }
+
+      html += `<p>${applyInlineFormatting(trimmed)}</p>`;
+    }
+
+    flushCode();
+    flushList();
+    flushQuote();
+
+    return html;
+  };
+
+  $: renderedBody = post ? renderMarkdown(post.body || "") : "";
+
+  const formattedDate = (value: string) => {
+    try {
+      return new Date(value).toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      });
+    } catch (error) {
+      return value;
+    }
+  };
+
+  function close() {
+    dispatch("close");
+  }
+</script>
+
+{#if open && post}
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-primary-text/40 backdrop-blur-sm px-4 py-6">
+    <div class="relative w-full max-w-4xl overflow-hidden rounded-3xl border border-border-ink/70 bg-card-bg shadow-xl shadow-black/20">
+      <button
+        type="button"
+        class="absolute right-4 top-4 inline-flex items-center justify-center rounded-full border border-border-ink/60 bg-card-bg px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-secondary-text transition hover:border-primary-text hover:text-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
+        on:click={close}
+      >
+        Close
+      </button>
+      <article class="max-h-[80vh] overflow-y-auto p-6 sm:p-10">
+        <header class="flex flex-col gap-6">
+          <p class="text-xs font-semibold uppercase tracking-[0.35em] text-muted-text">{post.category}</p>
+          <h2 class="font-display text-3xl leading-tight text-primary-text sm:text-4xl">{post.title}</h2>
+          <p class="text-lg text-secondary-text">{post.description}</p>
+          <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-secondary-text">
+            <span class="font-semibold text-primary-text">Preview</span>
+            <span aria-hidden="true">•</span>
+            <time datetime={post.pubDate}>{formattedDate(post.pubDate)}</time>
+            <span aria-hidden="true">•</span>
+            <span class="uppercase tracking-[0.25em] text-muted-text">{post.status}</span>
+          </div>
+          {#if post.heroImage}
+            <figure class="overflow-hidden rounded-2xl border border-border-ink/60 bg-surface-bg">
+              <img src={post.heroImage} alt={post.heroImageAlt || post.title} class="h-full w-full object-cover" loading="lazy" />
+            </figure>
+          {/if}
+        </header>
+        <section class="prose prose-neutral mt-10 max-w-none text-primary-text prose-headings:font-display prose-headings:text-primary-text prose-strong:text-primary-text prose-blockquote:border-l-4 prose-blockquote:border-border-ink prose-blockquote:pl-5 prose-blockquote:text-secondary-text prose-code:rounded prose-code:bg-surface-bg prose-code:px-1 prose-code:py-0.5 prose-code:text-sm prose-pre:bg-surface-bg">
+          {@html renderedBody}
+        </section>
+      </article>
+    </div>
+  </div>
+{/if}

--- a/src/components/Publishing/PublishingWorkspace.svelte
+++ b/src/components/Publishing/PublishingWorkspace.svelte
@@ -1,0 +1,517 @@
+<script lang="ts">
+  import RichTextEditor from "./RichTextEditor.svelte";
+  import PreviewModal from "./PreviewModal.svelte";
+  import DonutChart from "./DonutChart.svelte";
+  import type { PublishingPost, PublishingStatus } from "./types";
+
+  export let initialPosts: PublishingPost[] = [];
+  export let categoryOptions: string[] = [];
+
+  const palette = [
+    "rgb(var(--primary-text))",
+    "rgba(var(--secondary-text), 0.9)",
+    "rgba(var(--muted-text), 0.9)",
+    "rgba(var(--primary-text), 0.6)",
+    "rgba(var(--secondary-text), 0.6)",
+  ];
+
+  const buttonBaseClass =
+    "inline-flex items-center justify-center gap-2 rounded-full border border-border-ink/60 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text";
+  const primaryButtonClass =
+    `${buttonBaseClass} bg-primary-text text-primary-bg hover:bg-primary-bg hover:text-primary-text hover:border-primary-text`;
+  const secondaryButtonClass =
+    `${buttonBaseClass} bg-card-bg text-secondary-text hover:text-primary-text hover:border-primary-text`;
+  const ghostButtonClass =
+    `${buttonBaseClass} bg-transparent text-secondary-text hover:bg-primary-text hover:text-primary-bg hover:border-primary-text`;
+
+  const inputClass =
+    "w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-primary-text focus:outline-none focus:ring-2 focus:ring-border-ink/60";
+
+  type FormState = {
+    title: string;
+    description: string;
+    category: string;
+    pubDate: string;
+    heroImage: string;
+    heroImageAlt: string;
+    body: string;
+  };
+
+  const todayInputValue = () => new Date().toISOString().slice(0, 10);
+
+  const initialCategory = categoryOptions[0] ?? "Editorial";
+
+  const emptyForm = (): FormState => ({
+    title: "",
+    description: "",
+    category: initialCategory,
+    pubDate: todayInputValue(),
+    heroImage: "",
+    heroImageAlt: "",
+    body: "",
+  });
+
+  let form: FormState = emptyForm();
+  let drafts: PublishingPost[] = [];
+  let published: PublishingPost[] = initialPosts.filter((post) => post.status !== "draft");
+  let editingId: string | null = null;
+  let editingSource: "drafts" | "published" | null = null;
+  let previewOpen = false;
+  let previewTarget: PublishingPost | null = null;
+
+  let draftFilter = "all";
+  let draftSort = "recent";
+  let publishedFilter = "all";
+  let publishedSort = "recent";
+
+  const sortOptions = [
+    { value: "recent", label: "Newest" },
+    { value: "oldest", label: "Oldest" },
+    { value: "title", label: "Title A-Z" },
+  ];
+
+  $: if (categoryOptions.length > 0 && !categoryOptions.includes(form.category)) {
+    form = { ...form, category: categoryOptions[0] };
+  }
+
+  const computeStatus = (dateInput: string): PublishingStatus => {
+    const targetDate = new Date(dateInput);
+    const now = new Date();
+    return targetDate > now ? "scheduled" : "published";
+  };
+
+  const formatDate = (value: string) =>
+    new Date(value).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+
+  const buildPostFromForm = (status: PublishingStatus, id: string): PublishingPost => ({
+    id,
+    title: form.title.trim() || "Untitled draft",
+    description: form.description.trim() || "Refine this description before publishing.",
+    category: form.category,
+    pubDate: new Date(form.pubDate).toISOString(),
+    heroImage: form.heroImage.trim(),
+    heroImageAlt: form.heroImageAlt.trim(),
+    status,
+    body: form.body,
+  });
+
+  function resetForm() {
+    form = emptyForm();
+    editingId = null;
+    editingSource = null;
+  }
+
+  function populateForm(post: PublishingPost, source: "drafts" | "published") {
+    form = {
+      title: post.title,
+      description: post.description,
+      category: post.category,
+      pubDate: post.pubDate.slice(0, 10),
+      heroImage: post.heroImage ?? "",
+      heroImageAlt: post.heroImageAlt ?? "",
+      body: post.body,
+    };
+    editingId = post.id;
+    editingSource = source;
+  }
+
+  function ensureId() {
+    return editingId ?? crypto.randomUUID();
+  }
+
+  function saveDraft() {
+    const id = editingSource === "drafts" ? ensureId() : crypto.randomUUID();
+    const draft = buildPostFromForm("draft", id);
+    if (editingSource === "drafts") {
+      drafts = drafts.map((item) => (item.id === id ? draft : item));
+    } else {
+      drafts = [draft, ...drafts];
+    }
+    editingId = draft.id;
+    editingSource = "drafts";
+  }
+
+  function publishFromForm() {
+    const id =
+      editingSource === "drafts" || editingSource === "published"
+        ? ensureId()
+        : crypto.randomUUID();
+    const status = computeStatus(form.pubDate);
+    const post = buildPostFromForm(status, id);
+    if (editingSource === "published") {
+      published = published.map((item) => (item.id === id ? post : item));
+    } else {
+      if (editingSource === "drafts") {
+        drafts = drafts.filter((item) => item.id !== id);
+      }
+      published = [post, ...published];
+    }
+    editingId = post.id;
+    editingSource = "published";
+  }
+
+  function previewForm() {
+    const id =
+      editingSource === "drafts" || editingSource === "published"
+        ? ensureId()
+        : crypto.randomUUID();
+    const status = editingSource === "drafts" ? "draft" : computeStatus(form.pubDate);
+    previewTarget = buildPostFromForm(status, id);
+    previewOpen = true;
+  }
+
+  function removePost(post: PublishingPost, source: "drafts" | "published") {
+    if (source === "drafts") {
+      drafts = drafts.filter((item) => item.id !== post.id);
+    } else {
+      published = published.filter((item) => item.id !== post.id);
+    }
+    if (editingId === post.id) {
+      resetForm();
+    }
+  }
+
+  function duplicatePost(post: PublishingPost) {
+    const duplicate: PublishingPost = {
+      ...post,
+      id: crypto.randomUUID(),
+      title: `${post.title} (Copy)`
+        .replace(/\s+/g, " ")
+        .trim(),
+      status: "draft",
+    };
+    drafts = [duplicate, ...drafts];
+    populateForm(duplicate, "drafts");
+  }
+
+  function publishPost(post: PublishingPost) {
+    const status = computeStatus(post.pubDate);
+    const updated: PublishingPost = { ...post, status };
+    drafts = drafts.filter((item) => item.id !== post.id);
+    published = [updated, ...published.filter((item) => item.id !== post.id)];
+  }
+
+  function unpublishPost(post: PublishingPost) {
+    const draft: PublishingPost = { ...post, status: "draft" };
+    published = published.filter((item) => item.id !== post.id);
+    drafts = [draft, ...drafts];
+  }
+
+  function previewPost(post: PublishingPost) {
+    previewTarget = post;
+    previewOpen = true;
+  }
+
+  const applyFilterAndSort = (
+    posts: PublishingPost[],
+    filterValue: string,
+    sortValue: string
+  ) => {
+    let filtered = posts;
+    if (filterValue !== "all") {
+      filtered = filtered.filter((post) => post.category === filterValue);
+    }
+
+    const sorted = [...filtered];
+    switch (sortValue) {
+      case "title":
+        sorted.sort((a, b) => a.title.localeCompare(b.title));
+        break;
+      case "oldest":
+        sorted.sort((a, b) => new Date(a.pubDate).valueOf() - new Date(b.pubDate).valueOf());
+        break;
+      case "recent":
+      default:
+        sorted.sort((a, b) => new Date(b.pubDate).valueOf() - new Date(a.pubDate).valueOf());
+        break;
+    }
+
+    return sorted;
+  };
+
+  $: filteredDrafts = applyFilterAndSort(drafts, draftFilter, draftSort);
+  $: filteredPublished = applyFilterAndSort(published, publishedFilter, publishedSort);
+
+  $: totalDrafts = drafts.length;
+  $: totalPublished = published.filter((post) => post.status === "published").length;
+  $: totalScheduled = published.filter((post) => post.status === "scheduled").length;
+  $: totalPosts = totalDrafts + published.length;
+
+  $: categoryCounts = (() => {
+    const counts = new Map<string, number>();
+    for (const post of [...drafts, ...published]) {
+      const key = post.category || "Uncategorized";
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return Array.from(counts.entries()).map(([label, value]) => ({ label, value }));
+  })();
+
+  $: donutSegments = categoryCounts.map((entry, index) => ({
+    label: entry.label,
+    value: entry.value,
+    color: palette[index % palette.length],
+  }));
+
+  $: donutTotal = categoryCounts.reduce((total, entry) => total + entry.value, 0);
+
+  const legendBadgeClass =
+    "inline-flex items-center gap-2 rounded-full border border-border-ink/50 bg-surface-bg/60 px-3 py-1 text-xs font-medium uppercase tracking-[0.25em] text-secondary-text";
+</script>
+
+<div class="space-y-12">
+  <section class="space-y-6 rounded-3xl border border-border-ink/60 bg-card-bg/95 p-6 shadow-md shadow-black/10 sm:p-10">
+    <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+      <div class="space-y-2">
+        <h2 class="font-display text-2xl text-primary-text sm:text-3xl">Metrics at a glance</h2>
+        <p class="text-sm text-secondary-text">
+          Track how drafts and live posts spread across categories before you publish the next dispatch.
+        </p>
+      </div>
+      <DonutChart segments={donutSegments} total={donutTotal} />
+    </div>
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div class="rounded-2xl border border-border-ink/40 bg-surface-bg/60 p-4">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">Total posts</p>
+        <p class="mt-2 text-3xl font-semibold text-primary-text">{totalPosts}</p>
+      </div>
+      <div class="rounded-2xl border border-border-ink/40 bg-surface-bg/60 p-4">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">Drafts</p>
+        <p class="mt-2 text-3xl font-semibold text-primary-text">{totalDrafts}</p>
+      </div>
+      <div class="rounded-2xl border border-border-ink/40 bg-surface-bg/60 p-4">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">Published</p>
+        <p class="mt-2 text-3xl font-semibold text-primary-text">{totalPublished}</p>
+      </div>
+      <div class="rounded-2xl border border-border-ink/40 bg-surface-bg/60 p-4">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">Scheduled</p>
+        <p class="mt-2 text-3xl font-semibold text-primary-text">{totalScheduled}</p>
+      </div>
+    </div>
+    <div class="flex flex-wrap gap-3">
+      {#if donutSegments.length === 0}
+        <span class={legendBadgeClass}>No categories yet</span>
+      {:else}
+        {#each donutSegments as segment, index}
+          <span class={legendBadgeClass} style={`border-color: ${segment.color}; color: ${segment.color}`}>
+            <span class="h-2 w-2 rounded-full" style={`background-color: ${segment.color}`}></span>
+            {segment.label} · {segment.value}
+          </span>
+        {/each}
+      {/if}
+    </div>
+  </section>
+
+  <section class="space-y-8 rounded-3xl border border-border-ink/60 bg-card-bg/95 p-6 shadow-md shadow-black/10 sm:p-10">
+    <header class="space-y-2">
+      <h2 class="font-display text-2xl text-primary-text sm:text-3xl">Compose</h2>
+      <p class="text-sm text-secondary-text">
+        Shape the next essay with the same calm cadence readers expect on the live site.
+      </p>
+    </header>
+
+    <form class="space-y-6">
+      <div class="grid gap-5 md:grid-cols-2">
+        <div class="space-y-2">
+          <label for="publishing-title" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Title</label>
+          <input
+            id="publishing-title"
+            type="text"
+            class={inputClass}
+            bind:value={form.title}
+            placeholder="Working headline"
+          />
+        </div>
+        <div class="space-y-2">
+          <label for="publishing-category" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text"
+            >Category</label
+          >
+          <select id="publishing-category" class={inputClass} bind:value={form.category}>
+            {#each categoryOptions as option}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+        </div>
+      </div>
+      <div class="space-y-2">
+        <label for="publishing-description" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text"
+          >Description</label
+        >
+        <textarea
+          id="publishing-description"
+          rows={3}
+          class={`${inputClass} min-h-[120px]`}
+          placeholder="One-line dek to situate the story"
+          bind:value={form.description}
+        ></textarea>
+      </div>
+      <div class="grid gap-5 md:grid-cols-2">
+        <div class="space-y-2">
+          <label for="publishing-date" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text"
+            >Publication date</label
+          >
+          <input id="publishing-date" type="date" class={inputClass} bind:value={form.pubDate} />
+        </div>
+        <div class="space-y-2">
+          <label for="publishing-cover" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text"
+            >Cover image URL</label
+          >
+          <input
+            id="publishing-cover"
+            type="url"
+            class={inputClass}
+            bind:value={form.heroImage}
+            placeholder="https://"
+          />
+        </div>
+      </div>
+      <div class="space-y-2">
+        <label for="publishing-cover-alt" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text"
+          >Cover image alt text</label
+        >
+        <input
+          id="publishing-cover-alt"
+          type="text"
+          class={inputClass}
+          bind:value={form.heroImageAlt}
+          placeholder="Describe the tone of the visual"
+        />
+      </div>
+
+      <RichTextEditor bind:value={form.body} label="Body" placeholder="Write with long-form calm and precise rhythm." />
+
+      <div class="flex flex-wrap gap-3 pt-2">
+        <button type="button" class={primaryButtonClass} on:click={saveDraft}>
+          {editingSource === "drafts" ? "Update draft" : "Save draft"}
+        </button>
+        <button type="button" class={secondaryButtonClass} on:click={publishFromForm}>
+          {editingSource === "published" ? "Update publish" : "Publish"}
+        </button>
+        <button type="button" class={ghostButtonClass} on:click={previewForm}>Preview</button>
+        <button type="button" class={ghostButtonClass} on:click={resetForm}>Clear form</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="grid gap-8 lg:grid-cols-2">
+    <div class="space-y-5 rounded-3xl border border-border-ink/60 bg-card-bg/95 p-6 shadow-md shadow-black/10">
+      <header class="space-y-3">
+        <div class="flex items-center justify-between">
+          <div>
+            <h3 class="font-display text-xl text-primary-text">Drafts</h3>
+            <p class="text-sm text-secondary-text">Ideas still in refinement before going live.</p>
+          </div>
+          <button type="button" class={ghostButtonClass} on:click={resetForm}>New draft</button>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <select class={`${inputClass} h-11 w-40 text-sm`} bind:value={draftFilter}>
+            <option value="all">All categories</option>
+            {#each categoryOptions as option}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+          <select class={`${inputClass} h-11 w-40 text-sm`} bind:value={draftSort}>
+            {#each sortOptions as option}
+              <option value={option.value}>{option.label}</option>
+            {/each}
+          </select>
+        </div>
+      </header>
+      <div class="space-y-3">
+        {#if filteredDrafts.length === 0}
+          <p class="rounded-2xl border border-dashed border-border-ink/50 bg-surface-bg/70 px-4 py-6 text-sm text-secondary-text">
+            No drafts yet. Start a new entry to see it appear here.
+          </p>
+        {:else}
+          {#each filteredDrafts as post}
+            <article class="space-y-3 rounded-2xl border border-border-ink/50 bg-surface-bg/70 p-4">
+              <div class="flex items-start justify-between gap-4">
+                <div class="space-y-1">
+                  <h4 class="font-semibold text-primary-text">{post.title}</h4>
+                  <p class="text-sm text-secondary-text">{post.description}</p>
+                  <div class="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.25em] text-muted-text">
+                    <span>{post.category}</span>
+                    <span aria-hidden="true">•</span>
+                    <time datetime={post.pubDate}>{formatDate(post.pubDate)}</time>
+                  </div>
+                </div>
+                <span class="rounded-full bg-primary-text/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-primary-text">
+                  Draft
+                </span>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                <button type="button" class={secondaryButtonClass} on:click={() => populateForm(post, "drafts")}>Edit</button>
+                <button type="button" class={ghostButtonClass} on:click={() => previewPost(post)}>Preview</button>
+                <button type="button" class={primaryButtonClass} on:click={() => publishPost(post)}>Publish</button>
+                <button type="button" class={ghostButtonClass} on:click={() => duplicatePost(post)}>Duplicate</button>
+                <button type="button" class={ghostButtonClass} on:click={() => removePost(post, "drafts")}>Delete</button>
+              </div>
+            </article>
+          {/each}
+        {/if}
+      </div>
+    </div>
+
+    <div class="space-y-5 rounded-3xl border border-border-ink/60 bg-card-bg/95 p-6 shadow-md shadow-black/10">
+      <header class="space-y-3">
+        <div class="flex items-center justify-between">
+          <div>
+            <h3 class="font-display text-xl text-primary-text">Published & Scheduled</h3>
+            <p class="text-sm text-secondary-text">Live posts and those queued for upcoming dates.</p>
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <select class={`${inputClass} h-11 w-40 text-sm`} bind:value={publishedFilter}>
+            <option value="all">All categories</option>
+            {#each categoryOptions as option}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+          <select class={`${inputClass} h-11 w-40 text-sm`} bind:value={publishedSort}>
+            {#each sortOptions as option}
+              <option value={option.value}>{option.label}</option>
+            {/each}
+          </select>
+        </div>
+      </header>
+      <div class="space-y-3">
+        {#if filteredPublished.length === 0}
+          <p class="rounded-2xl border border-dashed border-border-ink/50 bg-surface-bg/70 px-4 py-6 text-sm text-secondary-text">
+            Nothing live yet. Publish a draft to populate this table.
+          </p>
+        {:else}
+          {#each filteredPublished as post}
+            <article class="space-y-3 rounded-2xl border border-border-ink/50 bg-surface-bg/70 p-4">
+              <div class="flex items-start justify-between gap-4">
+                <div class="space-y-1">
+                  <h4 class="font-semibold text-primary-text">{post.title}</h4>
+                  <p class="text-sm text-secondary-text">{post.description}</p>
+                  <div class="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.25em] text-muted-text">
+                    <span>{post.category}</span>
+                    <span aria-hidden="true">•</span>
+                    <time datetime={post.pubDate}>{formatDate(post.pubDate)}</time>
+                  </div>
+                </div>
+                <span class="rounded-full bg-primary-text/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-primary-text">
+                  {post.status === "scheduled" ? "Scheduled" : "Published"}
+                </span>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                <button type="button" class={secondaryButtonClass} on:click={() => populateForm(post, "published")}>Edit</button>
+                <button type="button" class={ghostButtonClass} on:click={() => previewPost(post)}>Preview</button>
+                <button type="button" class={ghostButtonClass} on:click={() => duplicatePost(post)}>Duplicate</button>
+                <button type="button" class={ghostButtonClass} on:click={() => removePost(post, "published")}>Delete</button>
+                <button type="button" class={primaryButtonClass} on:click={() => unpublishPost(post)}>Unpublish</button>
+              </div>
+            </article>
+          {/each}
+        {/if}
+      </div>
+    </div>
+  </section>
+
+  <PreviewModal open={previewOpen} post={previewTarget} on:close={() => (previewOpen = false)} />
+</div>

--- a/src/components/Publishing/RichTextEditor.svelte
+++ b/src/components/Publishing/RichTextEditor.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  export let value = "";
+  export let label = "Body";
+  export let placeholder = "Draft your narrative";
+  export let id = "publishing-body";
+
+  const dispatch = createEventDispatcher();
+  let textareaRef: HTMLTextAreaElement | null = null;
+
+  const formattingActions: { id: string; label: string; description: string }[] = [
+    { id: "h2", label: "H2", description: "Insert a section heading" },
+    { id: "h3", label: "H3", description: "Insert a subheading" },
+    { id: "caps", label: "CAPS", description: "Transform selection to all caps" },
+    { id: "bold", label: "Bold", description: "Wrap selection in **bold**" },
+    { id: "italic", label: "Italic", description: "Wrap selection in _italic_" },
+    { id: "list", label: "List", description: "Start a bulleted list" },
+    { id: "quote", label: "Quote", description: "Insert a pull quote" },
+    { id: "code", label: "Code", description: "Insert a fenced code block" },
+    { id: "math", label: "Math", description: "Wrap selection in inline math markers" },
+    { id: "image", label: "Image", description: "Insert an inline image" },
+    { id: "attachment", label: "File", description: "Insert an inline attachment" },
+  ];
+
+  function updateValue(next: string) {
+    value = next;
+    dispatch("change", { value });
+  }
+
+  function handleInput(event: Event) {
+    const target = event.target as HTMLTextAreaElement;
+    updateValue(target.value);
+  }
+
+  function applyFormatting(actionId: string) {
+    if (!textareaRef) return;
+    const textarea = textareaRef;
+    const startPos = textarea.selectionStart;
+    const endPos = textarea.selectionEnd;
+    const currentValue = textarea.value;
+    const selectedText = currentValue.slice(startPos, endPos) || "";
+
+    const commitChange = (nextValue: string, cursorStart: number, cursorEnd: number) => {
+      updateValue(nextValue);
+      requestAnimationFrame(() => {
+        textareaRef?.setSelectionRange(cursorStart, cursorEnd);
+        textareaRef?.focus();
+      });
+    };
+
+    const insertInline = (before: string, after = "") => {
+      const insertion = before + selectedText + after;
+      const nextValue = currentValue.slice(0, startPos) + insertion + currentValue.slice(endPos);
+      const cursorStart = startPos + before.length;
+      const cursorEnd = cursorStart + selectedText.length;
+      commitChange(nextValue, cursorEnd, cursorEnd - after.length);
+    };
+
+    const insertBlock = (block: string) => {
+      const needsPrefix = startPos > 0 && currentValue[startPos - 1] !== "\n";
+      const needsSuffix = endPos < currentValue.length && currentValue[endPos] !== "\n";
+      const prefix = needsPrefix ? "\n" : "";
+      const suffix = needsSuffix ? "\n" : "";
+      const blockValue = `${prefix}${block}${suffix}`;
+      const nextValue = currentValue.slice(0, startPos) + blockValue + currentValue.slice(endPos);
+      const cursorPoint = startPos + blockValue.length;
+      commitChange(nextValue, cursorPoint, cursorPoint);
+    };
+
+    switch (actionId) {
+      case "h2":
+        insertInline("## ");
+        break;
+      case "h3":
+        insertInline("### ");
+        break;
+      case "caps": {
+        const nextValue =
+          currentValue.slice(0, startPos) + selectedText.toUpperCase() + currentValue.slice(endPos);
+        const cursorStart = startPos;
+        const cursorEnd = startPos + selectedText.length;
+        commitChange(nextValue, cursorStart, cursorEnd);
+        break;
+      }
+      case "bold":
+        insertInline("**", "**");
+        break;
+      case "italic":
+        insertInline("_", "_");
+        break;
+      case "list":
+        insertBlock(`- ${selectedText || "List item"}`);
+        break;
+      case "quote":
+        insertBlock(`> ${selectedText || "Pull a resonant line and place it here."}`);
+        break;
+      case "code":
+        insertBlock("```\n" + (selectedText || "const calm = true;") + "\n```");
+        break;
+      case "math":
+        insertInline("\\(", "\\)");
+        break;
+      case "image":
+        insertInline("![Describe the scene](https://)");
+        break;
+      case "attachment":
+        insertInline("[Attachment title](https://)");
+        break;
+    }
+  }
+</script>
+
+<div class="space-y-3">
+  <label for={id} class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">{label}</label>
+  <div class="space-y-2 rounded-2xl border border-border-ink/60 bg-surface-bg/80 p-3 shadow-sm">
+    <div class="flex flex-wrap gap-2">
+      {#each formattingActions as action}
+        <button
+          type="button"
+          class="inline-flex items-center justify-center rounded-full border border-border-ink/60 bg-card-bg px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-secondary-text transition hover:border-primary-text hover:text-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
+          title={action.description}
+          on:click={() => applyFormatting(action.id)}
+        >
+          {action.label}
+        </button>
+      {/each}
+    </div>
+    <textarea
+      id={id}
+      bind:this={textareaRef}
+      bind:value
+      rows={12}
+      placeholder={placeholder}
+      class="w-full resize-y rounded-2xl border border-border-ink/60 bg-card-bg px-4 py-3 text-base text-primary-text shadow-inner focus:border-primary-text focus:outline-none focus:ring-2 focus:ring-border-ink/60"
+      on:input={handleInput}
+    />
+  </div>
+</div>

--- a/src/components/Publishing/types.ts
+++ b/src/components/Publishing/types.ts
@@ -1,0 +1,14 @@
+export type PublishingStatus = "draft" | "published" | "scheduled";
+
+export type PublishingPost = {
+  id: string;
+  slug?: string;
+  title: string;
+  description: string;
+  category: string;
+  pubDate: string;
+  heroImage?: string;
+  heroImageAlt?: string;
+  status: PublishingStatus;
+  body: string;
+};

--- a/src/pages/publishing.astro
+++ b/src/pages/publishing.astro
@@ -1,458 +1,51 @@
 ---
 import PageLayout from "@/layouts/PageLayout.astro";
+import PublishingWorkspace from "@/components/Publishing/PublishingWorkspace.svelte";
+import type { PublishingPost } from "@/components/Publishing/types";
 import { CATEGORY_OPTIONS } from "@/utils/categories";
-import FormValidator from "@/components/Publishing/FormValidator.svelte";
-import { getCollection, type CollectionEntry } from "astro:content";
+import { getCollection } from "astro:content";
 
-// Intro copy for the Pitch section
-const introParagraphs = [
-  "Share upcoming stories or works-in-progress you'd like to see featured on Lefthand Journal.",
-  "We review every submission and follow up if the tone, research, and point of view align with our editorial mission.",
-];
-
-// Fetch and prepare blog data for the Studio section
 const rawPosts = await getCollection("blogs");
-type BlogEntry = CollectionEntry<"blogs">;
-
-const posts: BlogEntry[] = [...rawPosts].sort(
-  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
-);
-
 const now = new Date();
-const publishedPosts = posts.filter(
-  (post) => post.data.pubDate.valueOf() <= now.valueOf()
-);
-const scheduledPosts = posts.filter(
-  (post) => post.data.pubDate.valueOf() > now.valueOf()
-);
 
-// Studio metrics
-const metrics = [
-  { label: "Total entries", value: posts.length.toString() },
-  { label: "Published", value: publishedPosts.length.toString() },
-  { label: "Scheduled", value: scheduledPosts.length.toString() },
-  {
-    label: "Active categories",
-    value:
-      posts.length === 0
-        ? "0"
-        : CATEGORY_OPTIONS.filter((category) =>
-            posts.some((post) => post.data.category === category)
-          ).length.toString(),
-  },
-];
-
-// Category coverage
-const categoriesWithCounts = CATEGORY_OPTIONS.map((category) => ({
-  label: category,
-  count: posts.filter((post) => post.data.category === category).length,
+const initialPosts: PublishingPost[] = rawPosts.map((entry) => ({
+  id: entry.id,
+  slug: entry.slug,
+  title: entry.data.title,
+  description: entry.data.description,
+  category: entry.data.category,
+  pubDate: entry.data.pubDate.toISOString(),
+  heroImage: entry.data.heroImage ?? undefined,
+  heroImageAlt: entry.data.heroImageAlt ?? undefined,
+  status: entry.data.pubDate.valueOf() > now.valueOf() ? "scheduled" : "published",
+  body: entry.body,
 }));
-const maxCategoryCount = categoriesWithCounts.reduce(
-  (max, category) => Math.max(max, category.count),
-  0
-);
-const categoryCoverage = categoriesWithCounts.map((category) => ({
-  ...category,
-  percentage:
-    maxCategoryCount === 0
-      ? 0
-      : Math.round((category.count / maxCategoryCount) * 100),
-}));
-
-// Helpers & UI classes
-const formatDate = (date: Date) =>
-  new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(date);
-
-type QueueSection = {
-  title: string;
-  description: string;
-  posts: BlogEntry[];
-  empty: string;
-};
-
-const queueSections: QueueSection[] = [
-  {
-    title: "Scheduled",
-    description: "Posts queued with future publish dates.",
-    posts: scheduledPosts,
-    empty: "No scheduled posts. Schedule a dispatch to see it here.",
-  },
-  {
-    title: "Published",
-    description: "Live stories already available on the site.",
-    posts: publishedPosts,
-    empty: "No published posts yet. Publish a piece to populate this list.",
-  },
-];
-
-const checklistItems = [
-  {
-    title: "Clarity & lede",
-    description:
-      "Ground readers in the central idea within the opening paragraphs and trim redundant framing.",
-  },
-  {
-    title: "Voice & tone",
-    description:
-      "Maintain the calm, deliberate cadence of Lefthand Journal—short subheads, long-form sentences where they count.",
-  },
-  {
-    title: "Rhythm & visuals",
-    description:
-      "Balance paragraphs with pull quotes or imagery, and confirm alt text reflects the story's metaphor.",
-  },
-];
-
-const buttonBaseClass =
-  "inline-flex items-center justify-center gap-2 rounded-full border border-border-ink/70 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text";
-const primaryButtonClass = `${buttonBaseClass} bg-primary-text text-primary-bg hover:bg-primary-bg hover:text-primary-text hover:border-primary-text`;
-const secondaryButtonClass = `${buttonBaseClass} bg-card-bg text-secondary-text hover:text-primary-text hover:border-primary-text`;
-const ghostButtonClass = `${buttonBaseClass} bg-transparent text-secondary-text hover:bg-primary-text hover:text-primary-bg hover:border-primary-text`;
-const inputClass =
-  "w-full rounded-lg border border-border-ink/70 bg-card-bg px-4 py-3 text-base text-primary-text shadow-sm transition-colors duration-200 focus:border-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text";
-const checkboxClass =
-  "h-4 w-4 rounded border border-border-ink/70 accent-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text";
 ---
 
 <PageLayout
   title="Publishing"
-  description="Pitch a story and manage releases with the same calm precision."
+  description="Compose, review, and release stories without breaking the magazine's calm cadence."
 >
-  <!-- Pitch: submission form -->
-  <section class="mx-auto max-w-3xl">
-    <div class="rounded-3xl border border-border-ink/70 bg-card-bg/95 px-8 py-10 shadow-lg shadow-black/5">
-      <div class="space-y-4 text-center sm:text-left">
-        <h1 class="font-display text-4xl text-primary-text">Pitch your next piece</h1>
-        {introParagraphs.map((paragraph) => (
-          <p class="text-base text-secondary-text">{paragraph}</p>
-        ))}
-      </div>
-
-      <form class="mt-10 space-y-6" data-publishing-form novalidate>
-        <div class="flex flex-col gap-2">
-          <label for="title" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Title</label>
-          <input
-            id="title"
-            name="title"
-            type="text"
-            placeholder="Working headline"
-            class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
-            required
-            aria-invalid="false"
-            data-required-field
-            data-helper-id="title-helper"
-            data-validation-message="Add a short, descriptive title for your piece."
-          />
-        </div>
-
-        <div class="flex flex-col gap-2">
-          <label for="description" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Description</label>
-          <textarea
-            id="description"
-            name="description"
-            rows="4"
-            placeholder="What makes this story compelling?"
-            class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
-            required
-            aria-invalid="false"
-            data-required-field
-            data-helper-id="description-helper"
-            data-validation-message="Share a concise description so the editorial team has context."
-          ></textarea>
-        </div>
-
-        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
-          <div class="flex w-full flex-col gap-2">
-            <label for="pubDate" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Target publication date</label>
-            <input
-              id="pubDate"
-              name="pubDate"
-              type="date"
-              class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
-              required
-              aria-invalid="false"
-              data-required-field
-              data-helper-id="pubdate-helper"
-              data-validation-message="Let us know when you hope to publish."
-            />
-          </div>
-          <div class="flex w-full flex-col gap-2">
-            <label for="category" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Category</label>
-            <select
-              id="category"
-              name="category"
-              class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
-              required
-              aria-invalid="false"
-              data-required-field
-              data-helper-id="category-helper"
-              data-validation-message="Select the category that best fits your piece."
-            >
-              <option value="" disabled selected>Choose a category</option>
-              {CATEGORY_OPTIONS.map((option) => (
-                <option value={option}>{option}</option>
-              ))}
-            </select>
-          </div>
-        </div>
-
-        <div class="flex flex-col gap-3">
-          <label for="notes" class="text-sm font-semibold uppercase tracking-[0.35em] text-muted-text">Additional notes (optional)</label>
-          <textarea
-            id="notes"
-            name="notes"
-            rows="4"
-            placeholder="Links, research, or collaborators you'd like to highlight"
-            class="w-full rounded-2xl border border-border-ink/60 bg-surface-bg/80 px-4 py-3 text-base text-primary-text shadow-sm transition focus:border-border-ink focus:outline-none focus:ring-2 focus:ring-border-ink/60"
-          ></textarea>
-        </div>
-
-        <div class="flex items-center justify-between gap-6 border-t border-border-ink/50 pt-6">
-          <p class="text-sm text-secondary-text">
-            Our team responds within 5 business days. All submissions remain confidential.
-          </p>
-          <button
-            type="submit"
-            class="inline-flex items-center justify-center rounded-full bg-primary-text px-6 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-primary-bg transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-text/30"
-          >
-            Submit pitch
-          </button>
-        </div>
-      </form>
-    </div>
-
-    <!-- client-side validation for the pitch form -->
-    <FormValidator client:load />
-  </section>
-
-  <!-- Publishing Studio: metrics, coverage, queue -->
-  <section class="mt-16 flex flex-col gap-12">
-    <div class="flex flex-col gap-4">
-      <p class="text-sm uppercase tracking-[0.3em] text-muted-text">
-        Editorial control center
-      </p>
-      <h2 class="font-display text-3xl leading-tight text-primary-text sm:text-4xl">
-        Publish and manage with the same calm precision.
-      </h2>
-      <p class="max-w-3xl text-lg text-secondary-text">
-        This studio keeps every Lefthand dispatch on cadence. Capture new ideas,
-        review scheduled releases, and make sure each category continues to feel
-        balanced and intentional.
-      </p>
-    </div>
-
-    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-      {metrics.map((metric) => (
-        <div class="rounded-2xl border border-border-ink/70 bg-card-bg p-6 shadow-sm">
-          <p class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">
-            {metric.label}
-          </p>
-          <p class="mt-3 text-3xl font-display text-primary-text">
-            {metric.value}
-          </p>
-        </div>
-      ))}
-    </div>
-
-    <div class="grid gap-8 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
-      <section class="rounded-2xl border border-border-ink/70 bg-card-bg p-8 shadow-sm">
-        <div class="flex flex-col gap-3">
-          <h3 class="font-display text-2xl text-primary-text">
-            Create a new dispatch
-          </h3>
-          <p class="text-sm text-secondary-text">
-            Set the essentials before publishing. Drafts save instantly, and
-            publishing updates the archive, RSS feed, and category hubs.
-          </p>
-        </div>
-
-        <form class="mt-6 flex flex-col gap-6" aria-label="Create new post">
-          <label class="flex flex-col gap-2">
-            <span class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">Title</span>
-            <input id="title-studio" name="title" type="text" placeholder="Working title" class={inputClass} />
-          </label>
-
-          <label class="flex flex-col gap-2">
-            <span class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">Description</span>
-            <textarea
-              id="description-studio"
-              name="description"
-              rows={4}
-              placeholder="One paragraph that frames the idea for subscribers and social sharing."
-              class={inputClass}
-            ></textarea>
-          </label>
-
-          <div class="grid gap-4 sm:grid-cols-2">
-            <label class="flex flex-col gap-2">
-              <span class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">Publish date</span>
-              <input id="pubDate-studio" name="pubDate" type="date" class={inputClass} />
-            </label>
-            <label class="flex flex-col gap-2">
-              <span class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">Category</span>
-              <select id="category-studio" name="category" class={inputClass}>
-                <option value="">Select category</option>
-                {CATEGORY_OPTIONS.map((category) => (
-                  <option value={category}>{category}</option>
-                ))}
-              </select>
-            </label>
-          </div>
-
-          <div class="grid gap-4 sm:grid-cols-2">
-            <label class="flex flex-col gap-2">
-              <span class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">Hero image URL</span>
-              <input id="heroImage" name="heroImage" type="url" placeholder="https://"
-                class={inputClass} />
-            </label>
-            <label class="flex flex-col gap-2">
-              <span class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">Hero image alt text</span>
-              <input id="heroImageAlt" name="heroImageAlt" type="text" placeholder="Describe the metaphor the image delivers."
-                class={inputClass} />
-            </label>
-          </div>
-
-          <fieldset class="flex flex-col gap-3">
-            <legend class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">Distribution</legend>
-            <div class="flex flex-wrap items-center gap-6">
-              <label class="flex items-center gap-3 text-sm text-secondary-text">
-                <input type="checkbox" name="sendNewsletter" class={checkboxClass} />
-                Send to newsletter subscribers
-              </label>
-              <label class="flex items-center gap-3 text-sm text-secondary-text">
-                <input type="checkbox" name="featureHome" class={checkboxClass} />
-                Feature on home grid
-              </label>
-              <label class="flex items-center gap-3 text-sm text-secondary-text">
-                <input type="checkbox" name="enableComments" class={checkboxClass} />
-                Enable discussion thread
-              </label>
-            </div>
-          </fieldset>
-
-          <div class="flex flex-wrap gap-3">
-            <button type="button" class={secondaryButtonClass}>Save draft</button>
-            <button type="submit" class={primaryButtonClass}>Publish</button>
-            <button type="button" class={ghostButtonClass}>Preview</button>
-          </div>
-
-          <p class="text-xs text-muted-text">
-            Autosave captures changes every few seconds. Publishing will trigger
-            the RSS rebuild and refresh the on-site grids.
-          </p>
-        </form>
-      </section>
-
-      <div class="flex flex-col gap-6">
-        <section class="rounded-2xl border border-border-ink/70 bg-card-bg p-6 shadow-sm">
-          <h3 class="font-display text-xl text-primary-text">Publishing checklist</h3>
-          <p class="mt-2 text-sm text-secondary-text">
-            A quick audit before you press publish keeps the journal's quiet polish intact.
-          </p>
-          <ul class="mt-5 flex flex-col gap-4">
-            {checklistItems.map((item) => (
-              <li class="flex items-start gap-3 rounded-xl border border-border-ink/60 bg-surface-bg px-4 py-3">
-                <span class="mt-1 inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full bg-primary-text" />
-                <div class="flex flex-col gap-1">
-                  <p class="text-sm font-semibold text-primary-text">{item.title}</p>
-                  <p class="text-sm text-secondary-text">{item.description}</p>
-                </div>
-              </li>
-            ))}
-          </ul>
-          <div class="mt-6 flex flex-wrap gap-3">
-            <button type="button" class={secondaryButtonClass}>Open style guide</button>
-            <button type="button" class={ghostButtonClass}>Review analytics</button>
-          </div>
-        </section>
-
-        <section class="rounded-2xl border border-border-ink/70 bg-card-bg p-6 shadow-sm">
-          <h3 class="font-display text-xl text-primary-text">Category coverage</h3>
-          <p class="mt-2 text-sm text-secondary-text">
-            Balance the cadence across themes so readers see chess, geopolitics, philosophy, and technology in rhythm.
-          </p>
-          <ul class="mt-5 flex flex-col gap-3">
-            {categoryCoverage.map((category) => (
-              <li class="flex flex-col gap-3 rounded-xl border border-border-ink/60 bg-surface-bg px-4 py-4">
-                <div class="flex items-center justify-between">
-                  <div class="flex flex-col">
-                    <span class="text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">
-                      {category.label}
-                    </span>
-                    <span class="text-base text-primary-text">
-                      {category.count} {category.count === 1 ? "post" : "posts"}
-                    </span>
-                  </div>
-                  <button type="button" class={ghostButtonClass}>View</button>
-                </div>
-                <div class="h-1.5 w-full overflow-hidden rounded-full bg-border-ink/40">
-                  <div
-                    class="h-full bg-primary-text"
-                    style={`width: ${category.percentage}%`}
-                    aria-hidden="true"
-                  />
-                </div>
-              </li>
-            ))}
-          </ul>
-        </section>
-      </div>
-    </div>
-
-    <section class="rounded-2xl border border-border-ink/70 bg-card-bg p-8 shadow-sm">
-      <div class="flex flex-col gap-3">
-        <h3 class="font-display text-2xl text-primary-text">Publishing queue</h3>
-        <p class="text-sm text-secondary-text">
-          Monitor what's shipping soon and what's already live. Use the actions
-          below each post to adjust cadence or revisit published work.
+  <section class="mx-auto max-w-6xl py-12 sm:py-16">
+    <div class="space-y-12 rounded-3xl border border-border-ink/70 bg-card-bg/95 p-8 shadow-lg shadow-black/5 sm:p-12">
+      <header class="max-w-3xl space-y-4">
+        <p class="text-xs font-semibold uppercase tracking-[0.35em] text-muted-text">
+          Publishing studio
         </p>
-      </div>
+        <h1 class="font-display text-4xl leading-tight text-primary-text sm:text-5xl">
+          Keep the editorial rhythm steady
+        </h1>
+        <p class="text-lg text-secondary-text">
+          Draft essays, adjust typography, and move calmly from idea to publication. Every control below mirrors the
+          magazine's layout so you can focus on the writing.
+        </p>
+      </header>
 
-      <div class="mt-6 grid gap-8 lg:grid-cols-2">
-        {queueSections.map((section) => (
-          <div class="flex flex-col gap-4">
-            <div class="flex flex-col gap-1">
-              <h4 class="text-sm font-semibold uppercase tracking-[0.3em] text-muted-text">
-                {section.title}
-              </h4>
-              <p class="text-sm text-secondary-text">{section.description}</p>
-            </div>
-
-            {section.posts.length ? (
-              <ul class="flex flex-col divide-y divide-border-ink/60 overflow-hidden rounded-xl border border-border-ink/60 bg-surface-bg">
-                {section.posts.map((post) => (
-                  <li class="flex flex-col gap-4 px-5 py-4 sm:px-6">
-                    <div class="flex flex-col gap-2">
-                      <p class="text-base font-semibold text-primary-text">
-                        {post.data.title}
-                      </p>
-                      <div class="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-secondary-text">
-                        <span class="inline-flex items-center rounded-full border border-border-ink/60 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-secondary-text">
-                          {post.data.category}
-                        </span>
-                        <span>{formatDate(post.data.pubDate)}</span>
-                      </div>
-                    </div>
-                    <div class="flex flex-wrap gap-3">
-                      <a href={`/blog/${post.slug}`} class={secondaryButtonClass}>View post</a>
-                      <button type="button" class={ghostButtonClass}>Duplicate</button>
-                      <button type="button" class={ghostButtonClass}>Archive</button>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p class="rounded-xl border border-dashed border-border-ink/70 bg-surface-bg px-6 py-8 text-sm text-secondary-text">
-                {section.empty}
-              </p>
-            )}
-          </div>
-        ))}
-      </div>
-    </section>
+      <PublishingWorkspace
+        client:load
+        initialPosts={initialPosts}
+        categoryOptions={[...CATEGORY_OPTIONS]}
+      />
+    </div>
   </section>
 </PageLayout>


### PR DESCRIPTION
## Summary
- replace the legacy publishing page layout with a calmer shell that hosts a Svelte-based studio
- add interactive publishing workspace components for editing posts, managing drafts/published tables, and rendering a metrics donut card
- implement rich text tooling and a modal preview that mirrors the public article layout without external dependencies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd591ac87c832897c5e76312fa186c