### PR TITLE
Improve mobile navigation touch targets

### DIFF
--- a/src/components/Header/SmNavBar.svelte
+++ b/src/components/Header/SmNavBar.svelte
@@ -9,7 +9,7 @@
     const mobileMenuId = 'mobile-navigation-menu';
 
     const mobileNavLinkClass =
-        'appearance-none bg-transparent font-inherit text-[inherit] tracking-[inherit] block w-full pb-1 text-left font-semibold uppercase leading-none tracking-[0.2em] transition-colors duration-200 hover:text-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text';
+        'appearance-none bg-transparent font-inherit text-[inherit] tracking-[inherit] flex w-full items-center justify-between py-2 text-left font-semibold uppercase leading-none tracking-[0.2em] transition-colors duration-200 hover:text-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text';
 
     let showMenu = false;
     let showCategories = false;
@@ -175,7 +175,7 @@
                                     <li>
                                         <a
                                             href={`/categories/${category.slug}`}
-                                            class="block px-4 py-1.5 transition-colors duration-200 hover:text-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
+                                            class="flex w-full items-center justify-between px-4 py-2 transition-colors duration-200 hover:text-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
                                             on:click={closeMenu}
                                             role="menuitem"
                                         >


### PR DESCRIPTION
## Summary
- increase mobile navigation link padding and flex layout for larger touch targets
- apply the same spacing to category submenu links to ensure consistent tap comfort

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd5920cd2c83289cf1f2ef938251f7