### PR TITLE
Add search overlay for posts in header

### DIFF
--- a/src/components/Header/HeaderBtns.svelte
+++ b/src/components/Header/HeaderBtns.svelte
@@ -1,8 +1,10 @@
 <script> 
     import Icon from '@iconify/svelte';
     import { onMount } from 'svelte';
+    import SearchOverlay from './SearchOverlay.svelte';
 
     let theme = 'light';
+    let showSearch = false;
 
     const setTheme = (nextTheme) => {
         theme = nextTheme;
@@ -36,13 +38,31 @@
     onMount(() => {
         initialiseTheme();
     });
+
+    const openSearch = () => {
+        showSearch = true;
+    };
+
+    const closeSearch = () => {
+        showSearch = false;
+    };
 </script>
 
-<div class="flex items-center">
+<div class="flex items-center gap-3">
+    <button
+        on:click={openSearch}
+        class="flex h-10 w-10 items-center justify-center rounded-full border border-border-ink/80 bg-card-bg text-primary-text transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-text"
+        aria-label="Open search"
+        type="button"
+    >
+        <Icon icon="tabler:search" class="h-5 w-5" />
+    </button>
+
     <button
         on:click={toggleTheme}
         class="flex h-10 w-10 items-center justify-center rounded-full border border-border-ink/80 bg-card-bg text-primary-text transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-text"
         aria-label={`Activate ${theme === 'light' ? 'dark' : 'light'} mode`}
+        type="button"
     >
         {#if theme === 'light'}
             <Icon icon="solar:sun-2-bold" class="h-5 w-5" />
@@ -50,4 +70,8 @@
             <Icon icon="solar:moon-bold" class="h-5 w-5" />
         {/if}
     </button>
+
+    {#if showSearch}
+        <SearchOverlay on:close={closeSearch} />
+    {/if}
 </div>

--- a/src/components/Header/SearchOverlay.svelte
+++ b/src/components/Header/SearchOverlay.svelte
@@ -1,0 +1,273 @@
+<script lang="ts">
+    import Icon from '@iconify/svelte';
+    import { createEventDispatcher, onDestroy, onMount, afterUpdate, tick } from 'svelte';
+    import { fade, scale } from 'svelte/transition';
+    
+    type SearchResult = {
+        title: string;
+        excerpt: string;
+        url: string;
+        slug: string;
+        pubDate?: string;
+        category?: string | null;
+    };
+
+    const dispatcher = createEventDispatcher();
+
+    let query = '';
+    let results: SearchResult[] = [];
+    let loading = false;
+    let error = '';
+    let inputRef: HTMLInputElement | null = null;
+    let panelRef: HTMLElement | null = null;
+    let abortController: AbortController | null = null;
+    let focusableElements: HTMLElement[] = [];
+    let debounceId: ReturnType<typeof setTimeout> | null = null;
+    let previousOverflow: string | null = null;
+
+    const close = () => {
+        dispatcher('close');
+    };
+
+    const updateFocusableElements = () => {
+        if (!panelRef) {
+            focusableElements = [];
+            return;
+        }
+
+        const selectors = [
+            'a[href]',
+            'button:not([disabled])',
+            'input:not([disabled])',
+            'textarea:not([disabled])',
+            'select:not([disabled])',
+            '[tabindex]:not([tabindex="-1"])'
+        ];
+
+        focusableElements = Array.from(
+            panelRef.querySelectorAll<HTMLElement>(selectors.join(','))
+        ).filter((element) => !element.hasAttribute('aria-hidden'));
+    };
+
+    const handleKeydown = (event: KeyboardEvent) => {
+        if (!panelRef) {
+            return;
+        }
+
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            close();
+            return;
+        }
+
+        if (event.key === 'Tab') {
+            updateFocusableElements();
+
+            if (focusableElements.length === 0) {
+                event.preventDefault();
+                return;
+            }
+
+            const first = focusableElements[0];
+            const last = focusableElements[focusableElements.length - 1];
+            const active = document.activeElement as HTMLElement | null;
+
+            if (event.shiftKey) {
+                if (!active || active === first) {
+                    event.preventDefault();
+                    last.focus();
+                }
+            } else if (active === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        }
+    };
+
+    const performSearch = async (value: string) => {
+        if (abortController) {
+            abortController.abort();
+        }
+
+        if (!value) {
+            results = [];
+            loading = false;
+            error = '';
+            return;
+        }
+
+        abortController = new AbortController();
+        loading = true;
+        error = '';
+
+        try {
+            const response = await fetch(`/api/posts.json?q=${encodeURIComponent(value)}`, {
+                signal: abortController.signal,
+                headers: {
+                    Accept: 'application/json'
+                }
+            });
+
+            if (!response.ok) {
+                throw new Error('Request failed');
+            }
+
+            const payload = await response.json();
+            results = Array.isArray(payload?.results) ? payload.results : [];
+        } catch (err) {
+            if (err instanceof DOMException && err.name === 'AbortError') {
+                return;
+            }
+
+            error = 'Unable to fetch search results right now. Please try again soon.';
+        } finally {
+            if (!abortController?.signal.aborted) {
+                loading = false;
+            }
+            abortController = null;
+        }
+    };
+
+    const scheduleSearch = (value: string) => {
+        if (debounceId) {
+            clearTimeout(debounceId);
+        }
+
+        if (!value.trim()) {
+            if (abortController) {
+                abortController.abort();
+                abortController = null;
+            }
+            query = value;
+            results = [];
+            error = '';
+            loading = false;
+            return;
+        }
+
+        debounceId = setTimeout(() => {
+            performSearch(value.trim());
+        }, 250);
+    };
+
+    const handleInput = (event: Event) => {
+        const target = event.target as HTMLInputElement;
+        query = target.value;
+        scheduleSearch(query);
+    };
+
+    const handlePointerDown = (event: MouseEvent) => {
+        if (panelRef && !panelRef.contains(event.target as Node)) {
+            close();
+        }
+    };
+
+    onMount(async () => {
+        previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+        window.addEventListener('keydown', handleKeydown);
+        await tick();
+        updateFocusableElements();
+        inputRef?.focus();
+    });
+
+    afterUpdate(() => {
+        updateFocusableElements();
+    });
+
+    onDestroy(() => {
+        window.removeEventListener('keydown', handleKeydown);
+        if (abortController) {
+            abortController.abort();
+        }
+        if (debounceId) {
+            clearTimeout(debounceId);
+        }
+        if (previousOverflow !== null) {
+            document.body.style.overflow = previousOverflow;
+        } else {
+            document.body.style.removeProperty('overflow');
+        }
+    });
+</script>
+
+<svelte:window on:focusin={updateFocusableElements} on:pointerdown={handlePointerDown} />
+
+<div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-overlay/60 backdrop-blur"
+    transition:fade={{ duration: 150 }}
+>
+    <div
+        bind:this={panelRef}
+        class="relative mx-4 w-full max-w-2xl overflow-hidden rounded-3xl border border-border-ink/80 bg-page-bg text-primary-text shadow-xl"
+        on:click|stopPropagation
+        transition:scale={{ start: 0.95, duration: 150 }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search posts"
+    >
+        <button
+            class="absolute right-4 top-4 flex h-10 w-10 items-center justify-center rounded-full border border-border-ink/80 bg-card-bg text-primary-text transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-text"
+            type="button"
+            on:click={close}
+            aria-label="Close search"
+        >
+            <Icon icon="tabler:x" class="h-5 w-5" />
+        </button>
+
+        <form class="border-b border-border-ink/70 bg-card-bg/40 px-6 py-5" on:submit|preventDefault>
+            <label class="flex items-center gap-3">
+                <Icon icon="tabler:search" class="h-5 w-5 text-secondary-text" />
+                <input
+                    bind:this={inputRef}
+                    class="w-full border-0 bg-transparent text-base text-primary-text placeholder:text-secondary-text focus:outline-none"
+                    type="search"
+                    placeholder="Search posts"
+                    value={query}
+                    on:input={handleInput}
+                    autocomplete="off"
+                />
+            </label>
+        </form>
+
+        <div class="max-h-[60vh] overflow-y-auto px-6 py-6">
+            {#if !query.trim()}
+                <p class="text-sm leading-6 text-secondary-text">
+                    Start typing to find posts by title, summary, or body content.
+                </p>
+            {:else if (loading)}
+                <p class="text-sm leading-6 text-secondary-text">Searching…</p>
+            {:else if (error)}
+                <p class="text-sm leading-6 text-secondary-text">{error}</p>
+            {:else if (results.length === 0)}
+                <p class="text-sm leading-6 text-secondary-text">No posts matched your search.</p>
+            {:else}
+                <ul class="space-y-5">
+                    {#each results as result}
+                        <li>
+                            <a
+                                href={result.url}
+                                class="block rounded-2xl border border-transparent bg-transparent p-5 transition-colors duration-150 hover:border-border-ink/60 hover:bg-card-bg/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
+                            >
+                                <h3 class="text-lg font-semibold text-primary-text">{result.title}</h3>
+                                {#if result.excerpt}
+                                    <p class="mt-2 text-sm leading-6 text-secondary-text">{result.excerpt}</p>
+                                {/if}
+                            </a>
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
+        </div>
+    </div>
+</div>
+
+<style>
+    .bg-overlay\/60 {
+        background-color: rgba(15, 23, 42, 0.6);
+    }
+
+    [data-theme='light'] .bg-overlay\/60 {
+        background-color: rgba(15, 23, 42, 0.45);
+    }
+</style>

--- a/src/pages/api/posts.json.ts
+++ b/src/pages/api/posts.json.ts
@@ -1,0 +1,62 @@
+import type { APIRoute } from 'astro';
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+const normalise = (value: string | undefined | null): string => {
+    return value ? value.toLowerCase() : '';
+};
+
+const createExcerpt = (post: CollectionEntry<'blogs'>): string => {
+    if (post.data.description) {
+        return post.data.description;
+    }
+
+    const cleaned = (post.body ?? '')
+        .replace(/[`*_#>\[\]]+/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    if (cleaned.length <= 160) {
+        return cleaned;
+    }
+
+    return `${cleaned.slice(0, 157).trimEnd()}…`;
+};
+
+export const GET: APIRoute = async ({ url }) => {
+    const query = url.searchParams.get('q')?.trim().toLowerCase() ?? '';
+    const posts = await getCollection('blogs');
+
+    const filtered = query
+        ? posts.filter((post) => {
+              const title = normalise(post.data.title);
+              const description = normalise(post.data.description);
+              const body = normalise(post.body);
+
+              return [title, description, body].some((segment) => segment.includes(query));
+          })
+        : posts;
+
+    const results = filtered
+        .sort((a, b) => {
+            const aDate = new Date(a.data.pubDate ?? '').getTime();
+            const bDate = new Date(b.data.pubDate ?? '').getTime();
+            return bDate - aDate;
+        })
+        .slice(0, 20)
+        .map((post) => ({
+            slug: post.slug,
+            url: `/blog/${post.slug}`,
+            title: post.data.title,
+            excerpt: createExcerpt(post),
+            pubDate: post.data.pubDate,
+            category: post.data.category ?? null
+        }));
+
+    return new Response(JSON.stringify({ results }), {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'no-store'
+        }
+    });
+};


### PR DESCRIPTION
## Summary
- add a search trigger next to the header theme toggle and mount a new overlay
- implement a focus-trapped search overlay that fetches post results with smooth transitions
- expose an API endpoint to query blog posts by title, description, or body content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd591c0c288328bb1789e6e0e1b38e