### PR TITLE
Add back-to-top control

### DIFF
--- a/src/components/Common/BackToTop.svelte
+++ b/src/components/Common/BackToTop.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+
+  const SCROLL_THRESHOLD = 320;
+
+  let isVisible = false;
+
+  const handleScroll = () => {
+    if (typeof window === "undefined") return;
+    isVisible = window.scrollY > SCROLL_THRESHOLD;
+  };
+
+  const scrollToTop = () => {
+    if (typeof window === "undefined") return;
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  onMount(() => {
+    if (typeof window === "undefined") return;
+    handleScroll();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+  });
+
+  onDestroy(() => {
+    if (typeof window === "undefined") return;
+    window.removeEventListener("scroll", handleScroll);
+  });
+</script>
+
+<button
+  type="button"
+  class="fixed bottom-6 right-4 z-40 flex h-12 w-12 items-center justify-center rounded-full border border-border-ink/60 bg-primary-bg/90 text-primary-text shadow-lg shadow-black/10 backdrop-blur transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary-text/40 focus-visible:ring-offset-2 focus-visible:ring-offset-primary-bg"
+  class:opacity-100={isVisible}
+  class:pointer-events-auto={isVisible}
+  class:translate-y-0={isVisible}
+  class:opacity-0={!isVisible}
+  class:pointer-events-none={!isVisible}
+  class:translate-y-4={!isVisible}
+  aria-label="Back to top"
+  on:click={scrollToTop}
+>
+  <span class="sr-only">Back to top</span>
+  <svg
+    class="h-6 w-6 -rotate-90 text-primary-text drop-shadow"
+    viewBox="0 0 127 155"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <g transform="translate(0,155) scale(0.1,-0.1)" stroke="none">
+      <path
+        d="M125 1198 c-3 -24 -5 -259 -3 -523 l3 -480 523 -3 522 -2 0 525 0 525 -519 0 -520 0 -6 -42z m998 -80 c2 -40 4 -252 5 -470 0 -301 -3 -400 -12 -407 -8 -7 -174 -10 -477 -8 l-464 2 -3 478 -2 477 474 0 474 0 5 -72z"
+      />
+      <path
+        d="M482 1061 c-74 -15 -87 -22 -128 -61 -50 -50 -90 -108 -80 -117 4 -4 59 -9 123 -11 101 -4 114 -6 98 -18 -10 -8 -28 -12 -39 -9 -12 2 -59 6 -106 10 l-85 6 30 -32 c44 -46 106 -70 196 -76 86 -6 118 -24 86 -48 -10 -7 -36 -15 -58 -19 -23 -4 -51 -17 -66 -32 -28 -28 -24 -47 5 -68 27 24 40 21 34 -8 -6 -32 11 -32 32 0 9 14 43 38 74 52 65 31 75 52 41 88 -12 13 -20 26 -17 29 8 8 58 -54 58 -71 0 -19 -45 -64 -64 -64 -15 0 -56 -45 -56 -61 0 -16 22 -9 39 12 9 12 37 31 62 43 28 13 49 32 58 51 7 17 25 42 39 58 22 23 34 27 76 27 28 0 59 -7 69 -14 15 -12 9 -13 -45 -9 -73 6 -104 -11 -123 -68 -9 -26 -23 -40 -60 -59 -49 -25 -75 -53 -62 -66 3 -4 15 4 26 17 l19 24 -5 -28 c-6 -31 11 -37 26 -8 16 28 116 81 154 81 64 0 117 -64 117 -141 0 -56 -50 -109 -104 -109 -72 0 -112 79 -66 128 35 37 90 26 90 -18 0 -36 -24 -57 -45 -40 -14 12 -14 15 0 30 11 13 13 20 5 25 -30 19 -55 -56 -28 -83 19 -19 76 -14 98 8 24 24 27 86 5 117 -36 51 -133 47 -179 -8 -38 -44 -43 -89 -16 -145 63 -130 239 -119 313 20 20 37 22 56 22 186 0 97 -4 152 -12 167 -9 14 -9 23 -2 25 6 2 3 14 -9 28 -10 14 -17 30 -15 37 2 6 -5 17 -16 23 -12 6 -21 17 -21 25 0 7 -10 15 -22 17 -16 2 -22 9 -20 21 2 12 -4 17 -21 17 -14 0 -27 6 -30 14 -4 9 -14 12 -26 9 -15 -4 -21 -1 -21 11 0 12 -5 14 -25 6 -20 -7 -25 -6 -25 5 0 17 -16 20 -25 5 -7 -12 -26 -14 -24 -2 4 21 -3 23 -27 7 -22 -14 -28 -15 -35 -4 -6 11 -11 11 -21 1 -19 -19 -28 -14 -28 13 0 31 -17 31 -138 6z m-3 -72 c13 -24 13 -29 -2 -53 -31 -46 -97 -31 -97 23 0 60 71 81 99 30z"
+      />
+      <path d="M410 970 c0 -15 5 -20 18 -18 9 2 17 10 17 18 0 8 -8 16 -17 18 -13 2 -18 -3 -18 -18z" />
+    </g>
+  </svg>
+</button>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -3,6 +3,7 @@ import "@/styles/global.css";
 import { ViewTransitions } from "astro:transitions";
 import Header from "@/components/Header/Header.astro";
 import Footer from "@/components/Footer/Footer.astro";
+import BackToTop from "@/components/Common/BackToTop.svelte";
 
 interface Props {
   title?: string;
@@ -35,6 +36,7 @@ const metaDescription =
       <slot />
     </main>
     <Footer />
+    <BackToTop client:load />
     <script is:inline>
       const applyTheme = () => {
         try {


### PR DESCRIPTION
## Summary
- add a reusable BackToTop chameleon button that appears after scrolling and scrolls smoothly to the top
- embed the new client-loaded component in the shared page layout so it is available on every page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd591d6ab08328a706785a5571cf57