### PR TITLE
Shrink category pill spacing and typography

### DIFF
--- a/src/components/Common/CategoryPills.astro
+++ b/src/components/Common/CategoryPills.astro
@@ -8,12 +8,12 @@ interface Props {
 const { class: className = "" }: Props = Astro.props;
 ---
 
-<ul class={`flex flex-wrap gap-3 ${className}`}>
+<ul class={`flex flex-wrap gap-2 ${className}`}>
   {CATEGORY_LINKS.map((category) => (
     <li>
       <a
         href={`/categories/${category.slug}`}
-        class="inline-flex items-center rounded-full border border-border-ink/70 bg-card-bg px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-secondary-text transition-colors duration-200 hover:text-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
+        class="inline-flex items-center rounded-full border border-border-ink/70 bg-card-bg px-3 py-1.5 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-secondary-text transition-colors duration-200 hover:text-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
       >
         {category.label}
       </a>


### PR DESCRIPTION
## Summary
- reduce the category pill gap and padding so the chips take up less space
- decrease the pill label font size to match the slimmer styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd59208a70832896d1e5ed372eeef4