### PR TITLE
Refine navigation item styling transitions

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,32 +17,41 @@
     color-scheme: light;
   }
 @layer components {
-   /* links e botão de categoria: mesma transição */
-  .nav-link {
-    transition-property: color, border-color;
-    transition-duration: 300ms;
-    transition-timing-function: ease;
-    border-bottom-width: 1px;          /* borda SEMPRE presente (evita reflow) */
-    border-color: transparent;          /* cor muda só no estado ativo/hover */
+   /* Navegação: estilos consistentes para links e botões de categoria */
+  .nav-item {
+    color: rgb(var(--primary-text));
+    background-color: rgb(var(--card-bg));
+    border: 1px solid rgb(var(--border-ink));
+    transition: color 160ms ease, background-color 160ms ease, border-color 160ms ease, fill 160ms ease;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
-    }
+  }
+
+  .nav-item:hover,
+  .nav-item:focus-visible {
+    color: rgb(var(--secondary-text));
+    background-color: rgb(var(--surface-bg));
+    border-color: rgb(var(--secondary-text));
+  }
+
+  .nav-item:active,
+  .nav-item[aria-current="page"] {
+    color: rgb(var(--primary-text));
+    background-color: rgb(var(--surface-bg));
+    border-color: rgb(var(--primary-text));
+  }
+
   .nav-stable {
     font-kerning: normal;
     font-variant-ligatures: none;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
-  
-  
-  #desktop-category-button {
-    transition-property: color, border-color;
-    transition-duration: 300ms;
-    transition-timing-function: ease;
-    -webkit-font-smoothing: antialiased;   /* evita “engrossar” no toggle */
-    -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizeLegibility;
+  @media (prefers-reduced-motion: reduce) {
+    .nav-item {
+      transition: none;
+    }
   }
 
   /* Dropdown: mesma fluidez */


### PR DESCRIPTION
## Summary
- replace legacy navigation link styles with a unified nav-item rule using theme variables
- add hover, focus, and active states that derive from the design tokens
- respect reduced motion preferences by disabling nav item transitions when requested

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddac993c9c8328b4fbff25e0012eed