### PR TITLE
Add TinaCMS admin dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 
 # generated types
 .astro/
+tina/__generated__/
 
 # dependencies
 node_modules/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,28 @@ npm run dev
 
 The site runs at `http://localhost:4321` by default.
 
+### Managing content with TinaCMS
+
+TinaCMS is configured to edit the Markdown posts stored in `src/content/blogs` without changing their frontmatter structure. To
+run the editor locally:
+
+1. Install dependencies (includes the Tina CLI):
+   ```sh
+   npm install
+   ```
+2. Start the Tina development server alongside Astro:
+   ```sh
+   npm run tina:dev
+   ```
+   This command runs `tinacms dev -c "npm run dev"`, which proxies Git commits through the Tina local backend so every save wri
+   tes directly to the repository.
+3. Visit `http://localhost:4321/admin` to launch the Tina UI. Authenticate if prompted (the local backend will use your Git cre
+   dentials) and edit posts inline.
+4. Commit the generated Markdown updates in `src/content/blogs` once you finish editing.
+
+For a production build of the Tina admin, run `npm run tina:build`. The static assets are emitted to `public/admin` and can be
+served along with the site.
+
 ## Editing content
 
 - Articles live in `src/content/blogs`. Each Markdown file uses the following frontmatter:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,15 +14,20 @@
         "@astrojs/svelte": "^5.0.3",
         "@astrojs/tailwind": "^5.1.0",
         "@astrojs/vercel": "^7.7.0",
+        "@tinacms/app": "^1.0.3",
         "astro": "^4.2.8",
         "astro-icon": "^1.0.4",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "svelte": "^4.2.9",
         "tailwindcss": "^3.4.1",
+        "tinacms": "^2.5.0",
         "typescript": "^5.3.3"
       },
       "devDependencies": {
         "@iconify/svelte": "^3.1.6",
         "@tailwindcss/typography": "^0.5.13",
+        "@tinacms/cli": "^1.7.0",
         "prettier": "^3.2.4",
         "prettier-plugin-astro": "^0.13.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "tina:dev": "tinacms dev -c \"npm run dev\"",
+    "tina:build": "tinacms build"
   },
   "dependencies": {
     "@astrojs/check": "^0.4.1",
@@ -17,14 +19,19 @@
     "@astrojs/svelte": "^5.0.3",
     "@astrojs/tailwind": "^5.1.0",
     "@astrojs/vercel": "^7.7.0",
+    "@tinacms/app": "^1.0.3",
     "astro": "^4.2.8",
     "astro-icon": "^1.0.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tinacms": "^2.5.0",
     "svelte": "^4.2.9",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"
   },
   "devDependencies": {
     "@iconify/svelte": "^3.1.6",
+    "@tinacms/cli": "^1.7.0",
     "@tailwindcss/typography": "^0.5.13",
     "prettier": "^3.2.4",
     "prettier-plugin-astro": "^0.13.0"

--- a/src/pages/admin.astro
+++ b/src/pages/admin.astro
@@ -1,0 +1,26 @@
+---
+
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TinaCMS Admin</title>
+  </head>
+  <body>
+    <div id="tina-root">Loading TinaCMS…</div>
+    <script type="module">
+      import { TinaCMSApp } from "@tinacms/app";
+      import { createElement } from "react";
+      import { createRoot } from "react-dom/client";
+      import tinaConfig from "../../tina/config";
+
+      const target = document.getElementById("tina-root");
+      if (target) {
+        const root = createRoot(target);
+        root.render(createElement(TinaCMSApp, { config: tinaConfig }));
+      }
+    </script>
+  </body>
+</html>

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -1,0 +1,97 @@
+import { defineConfig } from "tinacms";
+
+const branch =
+  process.env.TINA_BRANCH ||
+  process.env.VERCEL_GIT_COMMIT_REF ||
+  process.env.HEAD ||
+  "main";
+
+const isLocal =
+  process.env.TINA_PUBLIC_IS_LOCAL === "true" ||
+  process.env.NODE_ENV === "development";
+
+export default defineConfig({
+  branch,
+  clientId: process.env.TINA_CLIENT_ID || "",
+  token: process.env.TINA_TOKEN || "",
+  localClient: isLocal,
+  build: {
+    outputFolder: "admin",
+    publicFolder: "public",
+  },
+  media: {
+    tina: {
+      mediaRoot: "",
+      publicFolder: "public",
+    },
+  },
+  schema: {
+    collections: [
+      {
+        label: "Blogs",
+        name: "blogs",
+        path: "src/content/blogs",
+        format: "md",
+        ui: {
+          defaultItem: {
+            author: "Lefthand Editorial",
+            category: "General",
+            heroImageAlt: "",
+          },
+        },
+        fields: [
+          {
+            type: "string",
+            name: "title",
+            label: "Title",
+            isTitle: true,
+            required: true,
+          },
+          {
+            type: "string",
+            name: "description",
+            label: "Description",
+            ui: {
+              component: "textarea",
+            },
+          },
+          {
+            type: "string",
+            name: "pubDate",
+            label: "Publish Date",
+            required: true,
+            ui: {
+              component: "date",
+              parse(value: string) {
+                return value ? value.split("T")[0] : value;
+              },
+            },
+          },
+          {
+            type: "string",
+            name: "category",
+            label: "Category",
+          },
+          {
+            type: "string",
+            name: "author",
+            label: "Author",
+          },
+          {
+            type: "image",
+            name: "heroImage",
+            label: "Hero Image",
+          },
+          {
+            type: "string",
+            name: "heroImageAlt",
+            label: "Hero Image Alt Text",
+            ui: {
+              component: "textarea",
+            },
+          },
+        ],
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- add TinaCMS dependencies and scripts to support the content editor
- define a Tina schema for the existing blog markdown and ignore generated artifacts
- add an Astro admin route that loads the Tina app and document the editorial workflow in the README

## Testing
- npm run build *(fails: tinacms packages unavailable in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb316446c8328b6ff5ce4dbd9a00a