### PR TITLE
Unify navigation transition timing

### DIFF
--- a/src/components/Header/HeaderBtns.svelte
+++ b/src/components/Header/HeaderBtns.svelte
@@ -202,7 +202,7 @@
         bind:this={searchButton}
         type="button"
         on:click={handleSearchButtonClick}
-        class="flex h-10 w-10 items-center justify-center rounded-full border border-border-ink/80 bg-card-bg text-primary-text transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-text"
+        class="flex h-10 w-10 items-center justify-center rounded-full border border-border-ink/80 bg-card-bg text-primary-text transition-colors nav-transition focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-text"
         aria-label={searchOpen ? 'Close search' : 'Open search'}
         aria-expanded={searchOpen}
         aria-haspopup="dialog"
@@ -211,7 +211,7 @@
     </button>
     <button
         on:click={toggleTheme}
-        class="flex h-10 w-10 items-center justify-center rounded-full border border-border-ink/80 bg-card-bg text-primary-text transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-text"
+        class="flex h-10 w-10 items-center justify-center rounded-full border border-border-ink/80 bg-card-bg text-primary-text transition-colors nav-transition focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-text"
         aria-label={`Activate ${theme === 'light' ? 'dark' : 'light'} mode`}
     >
         {#if theme === 'light'}
@@ -241,7 +241,7 @@
                 </div>
                 <button
                     type="button"
-                    class="flex h-9 w-9 items-center justify-center rounded-full border border-border-ink/70 text-secondary-text transition-colors duration-200 hover:text-primary-text focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-text"
+                    class="flex h-9 w-9 items-center justify-center rounded-full border border-border-ink/70 text-secondary-text transition-colors nav-transition hover:text-primary-text focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-text"
                     on:click={() => closeSearch()}
                     aria-label="Close search"
                 >
@@ -284,7 +284,7 @@
                             <li>
                                 <a
                                     href={result.url}
-                                    class="block rounded-2xl border border-transparent px-4 py-3 transition-colors duration-200 hover:border-border-ink/70 hover:bg-surface-bg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
+                                    class="block rounded-2xl border border-transparent px-4 py-3 transition-colors nav-transition hover:border-border-ink/70 hover:bg-surface-bg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
                                     on:click={() => closeSearch({ restoreFocus: false })}
                                 >
                                     <div class="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-muted-text">

--- a/src/components/Header/NavBar.astro
+++ b/src/components/Header/NavBar.astro
@@ -55,7 +55,7 @@ const focusRingClass =
       <div
         id={dropdownId}
         data-category-dropdown
-        class="absolute left-1/2 top-full mt-3 hidden w-48 -translate-x-1/2 translate-y-1 rounded-lg border border-border-ink/80 bg-card-bg py-3 opacity-0 shadow-sm transition-all duration-150 pointer-events-none"
+        class="absolute left-1/2 top-full mt-3 hidden w-48 -translate-x-1/2 translate-y-1 rounded-lg border border-border-ink/80 bg-card-bg py-3 opacity-0 shadow-sm transition-all nav-transition pointer-events-none"
         role="menu"
         aria-labelledby={buttonId}
         tabindex="-1"
@@ -66,7 +66,7 @@ const focusRingClass =
             <li>
               <a
                 href={`/categories/${category.slug}`}
-                class="block px-4 py-1.5 transition-colors duration-300 hover:text-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
+                class="block px-4 py-1.5 transition-colors nav-transition hover:text-primary-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
                 role="menuitem"
                 data-category-link
               >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,14 +14,16 @@
     --primary-text: 30 25 21;
     --secondary-text: 82 72 63;
     --muted-text: 128 118 109;
+    --nav-speed: 300ms;
+    --nav-ease: ease;
     color-scheme: light;
   }
 @layer components {
    /* links e botão de categoria: mesma transição */
   .nav-link {
     transition-property: color, border-color;
-    transition-duration: 300ms;
-    transition-timing-function: ease;
+    transition-duration: var(--nav-speed);
+    transition-timing-function: var(--nav-ease);
     border-bottom-width: 1px;          /* borda SEMPRE presente (evita reflow) */
     border-color: transparent;          /* cor muda só no estado ativo/hover */
     -webkit-font-smoothing: antialiased;
@@ -34,12 +36,12 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
-  
-  
+
+
   #desktop-category-button {
     transition-property: color, border-color;
-    transition-duration: 300ms;
-    transition-timing-function: ease;
+    transition-duration: var(--nav-speed);
+    transition-timing-function: var(--nav-ease);
     -webkit-font-smoothing: antialiased;   /* evita “engrossar” no toggle */
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
@@ -48,8 +50,13 @@
   /* Dropdown: mesma fluidez */
   [data-category-dropdown] {
     transition-property: opacity, transform;
-    transition-duration: 300ms;
-    transition-timing-function: linear;
+    transition-duration: var(--nav-speed);
+    transition-timing-function: var(--nav-ease);
+  }
+
+  .nav-transition {
+    transition-duration: var(--nav-speed);
+    transition-timing-function: var(--nav-ease);
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared navigation timing CSS custom properties and helper class
- update header navigation dropdown and search UI to consume the shared transition settings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddd8e98db08328b95bcfeb02ad455e