### PR TITLE
Set up TinaCMS scaffolding for content editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,41 @@ The site runs at `http://localhost:4321` by default.
 - Categories are locked to `Chess`, `Geopolitics`, `Philosophy`, and `Technology`. Update `src/utils/categories.ts` if you need to change or extend them.
 - Add or edit Markdown body copy below the frontmatter to update article pages.
 
+## TinaCMS content editing
+
+TinaCMS is configured to edit the Astro content collection directly. The Tina admin UI is
+exposed at `/admin` (served via `src/pages/admin/[...tina].astro`).
+
+### Environment variables
+
+Add the following variables to your `.env` file or hosting provider:
+
+| Variable | Description |
+| --- | --- |
+| `TINA_CLIENT_ID` | Tina Cloud client ID for the project. |
+| `TINA_TOKEN` | Tina Cloud read/write token. |
+| `TINA_BRANCH` | (Optional) Git branch to source content from. Defaults to `main`. |
+
+### Setup steps
+
+1. Install dependencies (requires access to Tina's public npm packages):
+   ```sh
+   npm install
+   ```
+2. Generate the Tina client output:
+   ```sh
+   npx tina@latest init
+   ```
+   This populates `.tina/__generated__` and builds the `/admin` SPA assets.
+3. Start Astro as normal:
+   ```sh
+   npm run dev
+   ```
+
+> **Note**
+> If your environment blocks access to scoped npm packages (e.g. `@tinacms/cli`), request access
+> or configure an authenticated registry mirror before running the commands above.
+
 ## Customising the look and feel
 
 - Global colours, fonts, and theme tokens are defined in `src/styles/global.css` and `tailwind.config.mjs`.

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TinaCMS Admin</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        padding: 2rem;
+        background: #0f172a;
+        color: #f1f5f9;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+      }
+      main {
+        max-width: 40rem;
+        line-height: 1.6;
+        background: rgba(15, 23, 42, 0.8);
+        border-radius: 1rem;
+        padding: 2.5rem;
+        box-shadow: 0 1rem 3rem rgba(15, 23, 42, 0.5);
+        backdrop-filter: blur(12px);
+      }
+      h1 {
+        font-size: 2rem;
+        margin-bottom: 1rem;
+      }
+      code {
+        font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        background: rgba(15, 23, 42, 0.6);
+        padding: 0.25rem 0.5rem;
+        border-radius: 0.5rem;
+      }
+      a {
+        color: #38bdf8;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>TinaCMS Admin</h1>
+      <p>
+        Tina's admin client assets have not been generated yet. Run
+        <code>npx tina@latest init</code> (after installing dependencies) to
+        create the files inside <code>.tina/__generated__</code> and refresh
+        this page.
+      </p>
+      <p>
+        See the <a href="/README">project README</a> for environment variable
+        details and setup instructions.
+      </p>
+    </main>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@astrojs/vercel": "^7.7.0",
         "astro": "^4.2.8",
         "astro-icon": "^1.0.4",
+        "tinacms": "^1.7.0",
         "svelte": "^4.2.9",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.3.3"
@@ -23,6 +24,7 @@
       "devDependencies": {
         "@iconify/svelte": "^3.1.6",
         "@tailwindcss/typography": "^0.5.13",
+        "@tinacms/cli": "^1.7.0",
         "prettier": "^3.2.4",
         "prettier-plugin-astro": "^0.13.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@astrojs/vercel": "^7.7.0",
     "astro": "^4.2.8",
     "astro-icon": "^1.0.4",
+    "tinacms": "^1.7.0",
     "svelte": "^4.2.9",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"
@@ -26,6 +27,7 @@
   "devDependencies": {
     "@iconify/svelte": "^3.1.6",
     "@tailwindcss/typography": "^0.5.13",
+    "@tinacms/cli": "^1.7.0",
     "prettier": "^3.2.4",
     "prettier-plugin-astro": "^0.13.0"
   }

--- a/src/pages/admin/[...tina].astro
+++ b/src/pages/admin/[...tina].astro
@@ -1,0 +1,8 @@
+---
+const segments = Astro.params.tina ?? [];
+const targetPath = Array.isArray(segments) && segments.length > 0
+  ? `/admin/${segments.join("/")}`
+  : "/admin/index.html";
+
+return Astro.redirect(targetPath);
+---

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "tinacms";
+import schema from "./schema";
+
+const branch =
+  process.env.TINA_BRANCH ||
+  process.env.VERCEL_GIT_COMMIT_REF ||
+  process.env.HEAD ||
+  "main";
+
+const clientId = process.env.TINA_CLIENT_ID ?? "";
+const token = process.env.TINA_TOKEN ?? "";
+
+export default defineConfig({
+  branch,
+  clientId,
+  token,
+  build: {
+    outputFolder: "admin",
+    publicFolder: "public",
+  },
+  media: {
+    tina: {
+      mediaRoot: "",
+      publicFolder: "public",
+    },
+  },
+  schema,
+});

--- a/tina/schema.ts
+++ b/tina/schema.ts
@@ -1,0 +1,66 @@
+import { CATEGORY_OPTIONS } from "../src/utils/categories";
+import type { Collection } from "tinacms";
+
+const blogsCollection: Collection = {
+  name: "blogs",
+  label: "Blog Posts",
+  path: "src/content/blogs",
+  format: "md",
+  fields: [
+    {
+      type: "string",
+      name: "title",
+      label: "Title",
+      required: true,
+    },
+    {
+      type: "string",
+      name: "description",
+      label: "Description",
+      required: true,
+      ui: {
+        component: "textarea",
+      },
+    },
+    {
+      type: "datetime",
+      name: "pubDate",
+      label: "Published Date",
+      required: true,
+      ui: {
+        dateFormat: "YYYY-MM-DD",
+      },
+    },
+    {
+      type: "string",
+      name: "category",
+      label: "Category",
+      required: true,
+      options: CATEGORY_OPTIONS.map((option) => ({ label: option, value: option })),
+    },
+    {
+      type: "string",
+      name: "author",
+      label: "Author",
+      required: true,
+    },
+    {
+      type: "image",
+      name: "heroImage",
+      label: "Hero Image",
+      required: false,
+    },
+    {
+      type: "string",
+      name: "heroImageAlt",
+      label: "Hero Image Alt Text",
+      required: false,
+    },
+  ],
+};
+
+const schema = {
+  collections: [blogsCollection],
+};
+
+export default schema;


### PR DESCRIPTION
## Summary
- add TinaCMS dependencies and configuration files with environment-driven API settings
- define a Tina schema that mirrors the Astro blog collection and expose an admin route
- scaffold admin placeholder assets and document the setup process and environment variables

## Testing
- npm install *(fails: registry returned 403 for @tinacms/cli; requires registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd8eb412c832896b94a64e14b88f6