### PR TITLE
Refine blog meta layout and share button

### DIFF
--- a/src/components/Utils/ShareButton.svelte
+++ b/src/components/Utils/ShareButton.svelte
@@ -76,10 +76,10 @@
     <button
         type="button"
         on:click={handleShare}
-        class="inline-flex items-center gap-2 rounded-full border border-border-ink/70 bg-card-bg px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-secondary-text transition-colors duration-200 hover:text-primary-text focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-text"
+        class="inline-flex items-center gap-1.5 rounded-full border border-border-ink/60 bg-card-bg/80 px-3 py-1.5 text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-secondary-text transition-colors duration-200 hover:border-primary-text hover:text-primary-text focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-text"
     >
-        <Icon icon={shareSupported ? 'ri:share-forward-line' : 'ri:file-copy-line'} class="h-4 w-4" />
-        <span>Share</span>
+        <Icon icon={shareSupported ? 'ri:share-forward-line' : 'ri:file-copy-line'} class="h-4 w-4 flex-shrink-0" />
+        <span class="leading-none">Share</span>
     </button>
     <span class="sr-only" aria-live="polite">{copied ? 'Link copied to clipboard' : ''}</span>
     {#if copied}

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -25,7 +25,7 @@ const shareUrl = Astro.site
         {title}
       </h1>
       <p class="text-lg text-secondary-text">{description}</p>
-      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex flex-wrap items-center gap-3 max-[360px]:flex-col max-[360px]:items-start">
         <div class="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-secondary-text">
           <span class="font-semibold text-primary-text">By {author}</span>
           <span aria-hidden="true">•</span>


### PR DESCRIPTION
## Summary
- tighten the share button styling to better match the author/date metadata
- keep the blog metadata row in a horizontal layout, only stacking on extremely narrow screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68decc7faddc83288adfbd25343a5bcf