### PR TITLE
Hide editorial description on small screens

### DIFF
--- a/src/components/Blog/EditorialCard.astro
+++ b/src/components/Blog/EditorialCard.astro
@@ -33,7 +33,7 @@ const heroImageAlt = data.heroImageAlt ?? data.title;
       <h2 class="font-display text-2xl leading-tight text-primary-text">
         {data.title}
       </h2>
-      <p class="text-base text-secondary-text">
+      <p class="hidden text-base text-secondary-text md:block">
         {data.description}
       </p>
       <div class="mt-auto">


### PR DESCRIPTION
## Summary
- hide the editorial card description on small screens while keeping it visible from the medium breakpoint upward

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68decc7f14d08328ada52e879a2db827