### PR TITLE
Normalize blog slugs for consistent routing

### DIFF
--- a/src/components/Blog/EditorialCard.astro
+++ b/src/components/Blog/EditorialCard.astro
@@ -1,12 +1,14 @@
 ---
 import type { CollectionEntry } from "astro:content";
+import { slugify } from "@/utils/slug";
 
 interface Props {
   post: CollectionEntry<"blogs">;
 }
 
 const { post }: Props = Astro.props;
-const { data, slug } = post;
+const { data } = post;
+const slug = slugify(data.title);
 const formattedDate = data.pubDate.toLocaleDateString("en-US", {
   month: "short",
   day: "2-digit",

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,14 +1,21 @@
 ---
 import { type CollectionEntry, getCollection } from "astro:content";
+import { slugify } from "@/utils/slug";
 import BlogLayout from "@/layouts/BlogLayout.astro";
 import Prose from "@/components/Utils/Prose.astro";
 
 export async function getStaticPaths() {
   const posts = await getCollection("blogs");
-  return posts.map((post) => ({
-    params: { slug: post.slug },
-    props: post,
-  }));
+  return posts.map((post) => {
+    const slug = slugify(post.data.title);
+    return {
+      params: { slug },
+      props: {
+        ...post,
+        slug,
+      },
+    };
+  });
 }
 type Props = CollectionEntry<"blogs">;
 

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,5 +1,6 @@
 import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
+import { slugify } from "@/utils/slug";
 
 export async function GET(context) {
   const posts = await getCollection("blogs");
@@ -8,11 +9,14 @@ export async function GET(context) {
     description:
       "Minimal editorial essays on chess, geopolitics, philosophy, and technology.",
     site: context.site,
-    items: posts.map((post) => ({
+    items: posts.map((post) => {
+      const slug = slugify(post.data.title);
+      return {
       title: post.data.title,
       description: post.data.description,
       pubDate: post.data.pubDate,
-      link: `/blog/${post.slug}/`,
-    })),
+      link: `/blog/${slug}/`,
+    };
+    }),
   });
 }

--- a/src/pages/search.json.ts
+++ b/src/pages/search.json.ts
@@ -1,4 +1,5 @@
 import { getCollection } from "astro:content";
+import { slugify } from "@/utils/slug";
 
 const normalise = (value: string) => value.replace(/\s+/g, " ").trim();
 
@@ -15,6 +16,7 @@ export async function GET() {
   const payload = posts
     .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
     .map((post) => {
+      const slug = slugify(post.data.title);
       const rawBody = typeof post.body === "string" ? post.body : "";
       const cleanedBody = normalise(stripMarkdown(rawBody));
       const excerptSource = cleanedBody || post.data.description || "";
@@ -24,7 +26,7 @@ export async function GET() {
         title: post.data.title,
         description: post.data.description,
         category: post.data.category,
-        url: `/blog/${post.slug}`,
+        url: `/blog/${slug}`,
         excerpt: excerpt ? `${excerpt}${excerptSource.length > excerpt.length ? "…" : ""}` : "",
         pubDate: post.data.pubDate.toISOString(),
         searchField: normalise(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,7 @@
+import { slugify } from "./slug";
+
+export { slugify };
+
 export function nameToSlug(name: string): string {
-  return name.replace(/\s/g, "-");
+  return slugify(name);
 }

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,0 +1,10 @@
+export function slugify(value: string): string {
+  return value
+    .trim()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}


### PR DESCRIPTION
## Summary
- add a shared slug utility that normalizes titles to ASCII hyphenated strings
- update blog routing, cards, RSS, and search builders to use the normalized slug
- expose the helper through the utils index for reuse

## Testing
- npm run astro -- check

------
https://chatgpt.com/codex/tasks/task_e_68deea4dca60832884bb2386367dd13d