### PR TITLE
Refine desktop category dropdown transition

### DIFF
--- a/src/components/Header/NavBar.astro
+++ b/src/components/Header/NavBar.astro
@@ -55,7 +55,7 @@ const focusRingClass =
       <div
         id={dropdownId}
         data-category-dropdown
-        class="absolute left-1/2 top-full mt-3 hidden w-48 -translate-x-1/2 translate-y-1 rounded-lg border border-border-ink/80 bg-card-bg py-3 opacity-0 shadow-sm transition-all nav-transition pointer-events-none"
+        class="absolute left-1/2 top-full mt-3 hidden w-48 -translate-x-1/2 translate-y-1 rounded-lg border border-border-ink/80 bg-card-bg py-3 opacity-0 shadow-sm transition-opacity transition-transform nav-transition pointer-events-none"
         role="menu"
         aria-labelledby={buttonId}
         tabindex="-1"


### PR DESCRIPTION
## Summary
- replace the dropdown's `transition-all` utility with explicit opacity and transform transitions alongside the existing nav helper
- keep the JavaScript toggle logic aligned with opacity and translate class changes for smooth animations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deea4bc5c48328b32dde9238cb9d68