### PR TITLE
Refine blog post header layout

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,7 +1,8 @@
 ---
 import { getCollection, type CollectionEntry } from "astro:content";
-import BlogLayout from "@/layouts/BlogLayout.astro";
+import PageLayout from "@/layouts/PageLayout.astro";
 import Prose from "@/components/Utils/Prose.astro";
+import ShareButton from "@/components/Utils/ShareButton.svelte";
 
 export async function getStaticPaths() {
   const posts = await getCollection("blogs");
@@ -11,12 +12,94 @@ export async function getStaticPaths() {
   }));
 }
 
-const { post } = Astro.props as { post: CollectionEntry<"blogs"> };
+let post: CollectionEntry<"blogs"> | undefined = (
+  Astro.props as { post?: CollectionEntry<"blogs"> }
+).post;
+
+if (!post) {
+  const slug = Astro.params?.slug;
+  if (slug) {
+    const [match] = await getCollection("blogs", (entry) => entry.slug === slug);
+    post = match;
+  }
+}
+
+if (!post) {
+  throw new Error(`Post not found for slug: ${Astro.params?.slug ?? "unknown"}`);
+}
+
 const { Content } = await post.render();
+
+const { title, description, pubDate, author, heroImage, heroImageAlt, category } =
+  post.data;
+
+const formattedDate = pubDate.toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+
+const shareUrl = Astro.site
+  ? new URL(Astro.url.pathname, Astro.site).toString()
+  : Astro.url.href;
 ---
 
-<BlogLayout {...post}>
-  <Prose>
-    <Content />
-  </Prose>
-</BlogLayout>
+<PageLayout title={title} description={description}>
+  <article
+    class="mx-auto flex w-full max-w-4xl flex-col gap-12 py-6 sm:py-10"
+    data-post-article
+  >
+    <header class="flex flex-col gap-6" data-post-header>
+      <div
+        class="mx-auto w-full md:max-w-[46rem] lg:max-w-[50rem] xl:max-w-[52rem]"
+        data-post-header-category
+      >
+        <p class="text-xs font-semibold uppercase tracking-[0.35em] text-muted-text">
+          {category}
+        </p>
+      </div>
+
+      <div
+        class="mx-auto flex w-full flex-col items-center gap-4 text-center md:max-w-[46rem] lg:max-w-[50rem] xl:max-w-[52rem]"
+        data-post-header-title
+      >
+        <h1 class="mt-0.5 text-3xl font-semibold leading-snug text-primary-text md:text-4xl">
+          {title}
+        </h1>
+
+        <div class="flex flex-col items-center gap-3" data-post-header-meta>
+          <div
+            class="flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-sm text-secondary-text"
+          >
+            <span class="font-semibold text-primary-text">By {author}</span>
+            <span aria-hidden="true">•</span>
+            <time datetime={pubDate.toISOString()}>{formattedDate}</time>
+          </div>
+          <div class="flex justify-center" data-post-share>
+            <ShareButton client:idle url={shareUrl} title={title} />
+          </div>
+        </div>
+      </div>
+
+      {heroImage && (
+        <figure
+          class="overflow-hidden rounded-xl border border-border-ink/70 bg-surface-bg"
+          data-post-hero
+        >
+          <img
+            src={heroImage}
+            alt={heroImageAlt ?? title}
+            class="h-full w-full object-cover"
+            loading="lazy"
+          />
+        </figure>
+      )}
+    </header>
+
+    <section class="flex flex-col gap-10" data-post-content>
+      <Prose>
+        <Content />
+      </Prose>
+    </section>
+  </article>
+</PageLayout>


### PR DESCRIPTION
## Summary
- inline the blog post layout to control header structure and formatting
- center the title and author metadata while keeping the category pill aligned with the homepage width
- preserve share/hero functionality and add wrappers and SSR fallback helpers for future enhancements

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e229a683bc83288b687ca6a6708e76