### PR TITLE
Add scoped image styling for blog posts

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -16,7 +16,25 @@ const { Content } = await post.render();
 ---
 
 <BlogLayout {...post}>
-  <Prose>
-    <Content />
-  </Prose>
+  <div data-post-content>
+    <Prose>
+      <Content />
+    </Prose>
+  </div>
 </BlogLayout>
+
+<style is:scoped>
+  [data-post-content] img {
+    width: 100%;
+    height: auto;
+    margin-inline: auto;
+    display: block;
+  }
+
+  @media (min-width: 768px) {
+    [data-post-content] img {
+      max-width: 720px;
+      max-height: 720px;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- wrap the blog post prose content with a data attribute wrapper
- add scoped styles to constrain blog post images on desktop while keeping mobile widths at 100%
- ensure image centering and lazy-loading behavior remain intact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e229a7c1bc83288156ae88f7254195