### PR TITLE
Rebrand UI strings and categories for Levogiro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Lefthand Journal
+# Levogiro
 
-Minimal editorial blog built with [Astro](https://astro.build) and Tailwind CSS. The project reimagines the original template as a calm magazine-inspired layout with light/dark themes, responsive editorial cards, and focused typography.
+Revista digital minimalista construída com [Astro](https://astro.build) e Tailwind CSS. O projeto apresenta um layout inspirado em revistas, com temas claro/escuro, cards editoriais responsivos e tipografia focada na leitura.
 
 ## Getting started
 
@@ -19,14 +19,19 @@ The site runs at `http://localhost:4321` by default.
   title: "Article title"
   description: "One-sentence dek that appears in cards."
   pubDate: 2024-02-12
-  category: "Chess" # Chess | Geopolitics | Philosophy | Technology
-  author: "Lefthand Editorial"
+  category: "TECNOLOGIA" # TECNOLOGIA | ARTE & CULTURA | GEOPOLÍTICA | XADREZ | OUTROS
+  author: "Levogiro"
   heroImage: "https://..." # optional 16:9 image
   heroImageAlt: "Accessible alt text"
   ---
   ```
-- Categories are locked to `Chess`, `Geopolitics`, `Philosophy`, and `Technology`. Update `src/utils/categories.ts` if you need to change or extend them.
+- Categories are locked to `TECNOLOGIA`, `ARTE & CULTURA`, `GEOPOLÍTICA`, `XADREZ`, e `OUTROS`. Atualize `src/utils/categories.ts` se precisar alterar ou ampliar a lista.
 - Add or edit Markdown body copy below the frontmatter to update article pages.
+- After editing category definitions or the Tina schema, run:
+
+  ```sh
+  npm run build:cms
+  ```
 
 ## TinaCMS content editing
 

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Lefthand Journal",
-  "short_name": "Lefthand Journal",
+  "name": "Levogiro",
+  "short_name": "Levogiro",
   "description": null,
   "dir": "auto",
   "lang": "en-US",

--- a/src/components/Header/NavBar.astro
+++ b/src/components/Header/NavBar.astro
@@ -9,7 +9,6 @@ const linkBase =
 
 <nav class="hidden md:block">
   <ul class="flex items-center gap-8 text-sm font-semibold uppercase tracking-[0.2em] leading-none">
-    <!-- ... HOME link unchanged ... -->
     <li>
       <a
         href="/"
@@ -50,7 +49,7 @@ const linkBase =
           <li class="my-1 h-px bg-border-ink/60"></li>
           <li>
             <a href="/categories" class="block rounded px-3 py-2 text-xs uppercase tracking-[0.28em] text-secondary-text hover:text-primary-text ui-transition">
-              OUTRAS
+              TODOS OS TÓPICOS
             </a>
           </li>
         </ul>

--- a/src/components/Header/SmNavBar.svelte
+++ b/src/components/Header/SmNavBar.svelte
@@ -86,7 +86,7 @@
     aria-controls="mobile-nav"
     on:click={toggleMenu}
     class="relative z-50 flex h-10 w-10 items-center justify-center rounded bg-transparent text-secondary-text hover:text-primary-text ui-transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text"
-    aria-label={open ? 'Close navigation' : 'Open navigation'}
+    aria-label={open ? 'Fechar navegação' : 'Abrir navegação'}
   >
     <Icon icon={open ? 'ri:close-line' : 'ri:menu-line'} class="pointer-events-none h-5 w-5" />
   </button>
@@ -136,7 +136,7 @@
               on:click={() => (showCats = !showCats)}
               aria-expanded={showCats}
             >
-              <span>CATEGORY</span>
+              <span>TÓPICOS</span>
               <Icon icon={showCats ? 'ri:arrow-up-s-line' : 'ri:arrow-down-s-line'} class="h-4 w-4" />
             </button>
 
@@ -157,7 +157,7 @@
                     href="/categories"
                     class="block rounded-[6px] px-4 py-2 text-xs uppercase tracking-[0.24em] hover:text-primary-text ui-transition"
                     on:click={() => closeMenu({ restoreFocus: false })}
-                  >OUTRAS</a>
+                  >TODOS OS TÓPICOS</a>
                 </li>
               </ul>
             {/if}

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -10,14 +10,14 @@ interface Props {
 }
 
 const { title = "", description }: Props = Astro.props;
-const pageTitle = title ? `${title} | Lefthand Journal` : "Lefthand Journal";
+const pageTitle = title ? `${title} | Levogiro` : "Levogiro";
 const metaDescription =
   description ??
-  "Lefthand Journal is a minimal editorial space exploring chess strategy, geopolitical shifts, technology, and philosophy.";
+  "Levogiro é uma revista digital em português sobre tecnologia, arte, cultura, geopolítica e xadrez.";
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <meta name="description" content={metaDescription} />

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -1,19 +1,19 @@
 ---
 import PageLayout from "@/layouts/PageLayout.astro";
 import { getCollection, type CollectionEntry } from "astro:content";
-import { CATEGORY_OPTIONS } from "@/utils/categories";
+import { CATEGORY_LINKS } from "@/utils/categories";
 import PostListItem from "@/components/PostListItem.astro";
 
 // Gera rotas estáticas a partir das opções
 export async function getStaticPaths() {
   const posts = await getCollection("blogs");
 
-  return CATEGORY_OPTIONS.map((label) => {
+  return CATEGORY_LINKS.map(({ label, slug }) => {
     const items = posts
-      .filter((p) => (p.data.category ?? "").toLowerCase() === label.toLowerCase())
+      .filter((p) => (p.data.category ?? "") === label)
       .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
-    return { params: { category: label.toLowerCase() }, props: { label, items } };
+    return { params: { category: slug }, props: { label, items } };
   });
 }
 
@@ -26,10 +26,14 @@ if (!label || !items) {
   const allPosts = await getCollection("blogs");
 
   // tenta achar o label canônico nas opções, senão usa o próprio slug
-  label = CATEGORY_OPTIONS.find((opt) => opt.toLowerCase() === slug) ?? slug;
+  const match = CATEGORY_LINKS.find((option) => option.slug === slug);
+  label = match?.label ?? slug.toUpperCase();
 
   items = allPosts
-    .filter((p) => (p.data.category ?? "").toLowerCase() === slug)
+    .filter((p) => {
+      const category = p.data.category ?? "";
+      return match ? category === match.label : category.toLowerCase() === slug;
+    })
     .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 }
 ---
@@ -38,7 +42,7 @@ if (!label || !items) {
     <!-- rótulo alinhado à mesma régua dos cards -->
     <div class="mx-auto w-full md:max-w-[46rem] lg:max-w-[50rem] xl:max-w-[52rem]">
       <p class="text-[12px] font-semibold uppercase tracking-[0.16em] text-muted-text">
-        CATEGORIA # {(label?.toUpperCase() ?? "")}
+        TÓPICO # {(label?.toUpperCase() ?? "")}
       </p>
     </div>
 
@@ -52,7 +56,7 @@ if (!label || !items) {
       </ul>
     ) : (
       <div class="mx-auto w-full md:max-w-[46rem] lg:max-w-[50rem] xl:max-w-[52rem]">
-        <p class="text-secondary-text">No posts in this category yet.</p>
+        <p class="text-secondary-text">Ainda não há publicações neste tópico.</p>
       </div>
     )}
   </section>

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -1,29 +1,23 @@
 ---
 import PageLayout from "@/layouts/PageLayout.astro";
 import { getCollection } from "astro:content";
-import { CATEGORY_LINKS, CATEGORY_OPTIONS } from "@/utils/categories";
+import { CATEGORY_LINKS } from "@/utils/categories";
 
 const posts = await getCollection("blogs");
-const summaries: Record<(typeof CATEGORY_OPTIONS)[number], string> = {
-  Chess: "Strategy, tempo, and the quiet mind required to end a game well.",
-  Geopolitics: "Supply lines, influence maps, and the narratives states publish.",
-  Philosophy: "Meaning-making for those who annotate their own interior lives.",
-  Technology: "Tools, protocols, and the systems shaping our collective attention.",
-};
 
-const categories = CATEGORY_LINKS.map(({ label, slug }) => ({
+const categories = CATEGORY_LINKS.map(({ label, slug, description }) => ({
   label,
   slug,
-  summary: summaries[label],
+  summary: description,
   count: posts.filter((post) => post.data.category === label).length,
 }));
 ---
 
-<PageLayout title="Categories">
+<PageLayout title="Tópicos">
   <section class="flex flex-col space-y-3 md:space-y-4">
     <!-- rótulo alinhado à mesma régua dos cards -->
     <div class="mx-auto w-full md:max-w-[46rem] lg:max-w-[50rem] xl:max-w-[52rem]">
-      <p class="text-[12px] font-semibold uppercase tracking-[0.16em] text-muted-text">CATEGORIES</p>
+      <p class="text-[12px] font-semibold uppercase tracking-[0.16em] text-muted-text">TÓPICOS</p>
     </div>
 
     <!-- grade alinhada à mesma régua dos cards -->
@@ -37,13 +31,13 @@ const categories = CATEGORY_LINKS.map(({ label, slug }) => ({
             >
               <div class="flex flex-col gap-2">
                 <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-text">
-                  {category.count} article{category.count === 1 ? "" : "s"}
+                  {category.count} artigo{category.count === 1 ? "" : "s"}
                 </p>
                 <h2 class="text-xl font-semibold text-primary-text">{category.label}</h2>
                 <p class="text-sm text-secondary-text">{category.summary}</p>
               </div>
               <span class="mt-5 text-xs font-semibold uppercase tracking-[0.16em] text-secondary-text">
-                View stories
+                Ver publicações
               </span>
             </a>
           </li>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -5,9 +5,8 @@ import { slugify } from "@/utils/slug";
 export async function GET(context) {
   const posts = await getCollection("blogs");
   return rss({
-    title: "Lefthand Journal",
-    description:
-      "Minimal editorial essays on chess, geopolitics, philosophy, and technology.",
+    title: "Levogiro",
+    description: "Ensaios em português sobre tecnologia, arte, cultura, geopolítica e xadrez.",
     site: context.site,
     items: posts.map((post) => {
       const slug = slugify(post.data.title);

--- a/src/utils/categories.ts
+++ b/src/utils/categories.ts
@@ -1,14 +1,31 @@
-export const CATEGORY_OPTIONS = [
-  "Chess",
-  "Geopolitics",
-  "Philosophy",
-  "Technology",
+export const CATEGORY_LINKS = [
+  {
+    label: "TECNOLOGIA",
+    slug: "tecnologia",
+    description: "Ferramentas, linguagens e impactos das inovações digitais.",
+  },
+  {
+    label: "ARTE & CULTURA",
+    slug: "arte-cultura",
+    description: "Crítica, processos criativos e movimentos culturais em destaque.",
+  },
+  {
+    label: "GEOPOLÍTICA",
+    slug: "geopolitica",
+    description: "Disputas globais, diplomacia e as narrativas que moldam o mundo.",
+  },
+  {
+    label: "XADREZ",
+    slug: "xadrez",
+    description: "Estratégias, partidas históricas e táticas do tabuleiro.",
+  },
+  {
+    label: "OUTROS",
+    slug: "outros",
+    description: "Ensaios diversos que desafiam classificações tradicionais.",
+  },
 ] as const;
 
-export type Category = (typeof CATEGORY_OPTIONS)[number];
+export type Category = (typeof CATEGORY_LINKS)[number]["label"];
 
-export const CATEGORY_LINKS = CATEGORY_OPTIONS.map((label) => ({
-  label,
-  slug: label.toLowerCase(),
-}));
-
+export const CATEGORY_OPTIONS = CATEGORY_LINKS.map((category) => category.label) as readonly Category[];


### PR DESCRIPTION
## Summary
- replace the category source of truth with the five Portuguese labels, slugs, and descriptions
- localize navigation, category pages, and site metadata around the Levogiro brand
- refresh manifest, RSS title, and README guidance for the new naming and TinaCMS workflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4944fe94c8328ac824345be62777e